### PR TITLE
feature/71-разработка-dto-на-основе-документации-swaggerui

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/data/network/CheckResponse.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/data/network/CheckResponse.kt
@@ -1,0 +1,7 @@
+package io.dimasla4ee.shoppinglist.core.data.network
+
+/** Используется в `/auth/check` эндпоинте. */
+data class CheckResponse(
+    val success: Boolean,
+    val refresh: Boolean
+): Response()

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/data/network/RefreshTokenResponse.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/data/network/RefreshTokenResponse.kt
@@ -1,0 +1,7 @@
+package io.dimasla4ee.shoppinglist.core.data.network
+
+/** Используется в `/auth/refresh` эндпоинте. */
+data class RefreshTokenResponse(
+    val accessToken: String,
+    val refreshToken: String
+) : Response()

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/data/network/RegisterResponse.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/data/network/RegisterResponse.kt
@@ -1,0 +1,8 @@
+package io.dimasla4ee.shoppinglist.core.data.network
+
+/** Используется в `/auth/registration` эндпоинте. */
+data class RegisterResponse(
+    val userId: Int,
+    val accessToken: String,
+    val refreshToken: String
+) : Response()

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/data/network/Request.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/data/network/Request.kt
@@ -1,0 +1,17 @@
+package io.dimasla4ee.shoppinglist.core.data.network
+
+/**
+ * Базовый интерфейс для запросов к серверу.
+ *
+ * [Документация к API](https://practicumopbackend-production.up.railway.app/swagger-ui/index.html)
+ * */
+sealed interface Request {
+    /** Используется в `/auth/registration` эндпоинте. */
+    data class RegisterRequest(val email: String, val password: String) : Request
+
+    /** Используется в `/auth/refresh` эндпоинте. */
+    data class RefreshTokenRequest(val refreshToken: String) : Request
+
+    /** Используется в `/auth/login` эндпоинте. */
+    data class UserAuthRequest(val email: String, val password: String) : Request
+}

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/data/network/Response.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/data/network/Response.kt
@@ -1,0 +1,10 @@
+package io.dimasla4ee.shoppinglist.core.data.network
+
+/**
+ * Базовый класс сетевых ответов.
+ *
+ * @param resultCode HTTP-код ответа.
+ */
+open class Response {
+    var resultCode = 0
+}

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/data/network/UserAuthResponse.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/data/network/UserAuthResponse.kt
@@ -1,0 +1,8 @@
+package io.dimasla4ee.shoppinglist.core.data.network
+
+/** Используется в `/auth/login` эндпоинте. */
+data class UserAuthResponse(
+    val userId: Int,
+    val accessToken: String,
+    val refreshToken: String
+): Response()


### PR DESCRIPTION
Resolves #71 

- Реализовал базовый интерфейс для запросов `Request`
- Реализовал DTO запросов:
    - `RegisterRequest`
    - `RefreshTokenRequest`
    - `UserAuthRequest`
- Реализовал базовый класс для запросов `Response`
- Реализовал DTO ответов:
    - `UserAuthResponse`
    - `RefreshTokenResponse`
    - `RegisterResponse`
    - `CheckResponse`
- Написал документацию к классам
- Удалил заглушку `.gitkeep`