### PR TITLE
feat(auth): Добавить экран авторизации и интеграцию MVI-состояний

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/presentation/recover_password/RecoverPasswordState.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/presentation/recover_password/RecoverPasswordState.kt
@@ -1,11 +1,12 @@
 package io.dimasla4ee.shoppinglist.feature.authorization.presentation.recover_password
 
 import androidx.compose.foundation.text.input.TextFieldState
+import io.dimasla4ee.shoppinglist.core.mvi.MviState
 import io.dimasla4ee.shoppinglist.core.utils.isValidEmail
 
 data class RecoverPasswordState(
     val email: TextFieldState
-) {
+) : MviState {
     val isRecoverEnabled: Boolean
         get() = email.text.isValidEmail()
 }

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/ui/AuthorizationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/ui/AuthorizationScreen.kt
@@ -1,0 +1,106 @@
+package io.dimasla4ee.shoppinglist.feature.authorization.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import io.dimasla4ee.shoppinglist.app.ui.theme.AppDimensions
+import io.dimasla4ee.shoppinglist.app.ui.theme.ShoppingListTheme
+import io.dimasla4ee.shoppinglist.app.ui.theme.noteworthyTypography
+import io.dimasla4ee.shoppinglist.feature.authorization.presentation.recover_password.RecoverPasswordState
+import io.dimasla4ee.shoppinglist.feature.authorization.presentation.register.RegisterState
+import io.dimasla4ee.shoppinglist.feature.authorization.presentation.sign_in.SignInState
+import io.dimasla4ee.shoppinglist.feature.authorization.ui.recover_password.RecoverPasswordContent
+import io.dimasla4ee.shoppinglist.feature.authorization.ui.register.RegisterContent
+import io.dimasla4ee.shoppinglist.feature.authorization.ui.sign_in.SignInContent
+import io.dimasla4ee.shoppinglist.feature.welcome_screen.ui.createWelcomeLogo
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun AuthorizationScreen(
+    modifier: Modifier = Modifier,
+    content: @Composable (PaddingValues) -> Unit
+) {
+    val (annotatedString, inlineContentMap) = createWelcomeLogo()
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            Box(
+                modifier = Modifier.fillMaxWidth().padding(vertical = AppDimensions.paddingLarge),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    inlineContent = inlineContentMap,
+                    text = annotatedString,
+                    style = noteworthyTypography().titleLargeEmphasized,
+                    color = MaterialTheme.colorScheme.onBackground,
+                    textAlign = TextAlign.Center
+                )
+            }
+
+        },
+    ) { paddingValues ->
+        content(paddingValues)
+    }
+}
+
+@Preview
+@PreviewLightDark
+@Composable
+private fun AuthorizationScreenPreview(
+    @PreviewParameter(AuthorizationScreenPreviewProvider::class) screenType: AuthorizationScreenType
+) = ShoppingListTheme {
+    AuthorizationScreen(Modifier.fillMaxSize()) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues),
+            contentAlignment = Alignment.Center
+        ) {
+            when (screenType) {
+                AuthorizationScreenType.RecoverPassword -> {
+                    RecoverPasswordContent(
+                        state = screenType.state as RecoverPasswordState,
+                        onRecoverPassword = {},
+                        onCancel = {},
+                        modifier = Modifier.padding(horizontal = AppDimensions.paddingMedium)
+                    )
+                }
+
+                AuthorizationScreenType.Register -> {
+                    RegisterContent(
+                        state = screenType.state as RegisterState,
+                        onShowPassword = {},
+                        onRegister = {},
+                        onAuthorization = {},
+                        modifier = Modifier.padding(horizontal = AppDimensions.paddingMedium)
+                    )
+                }
+
+                AuthorizationScreenType.SignIn -> {
+                    SignInContent(
+                        state = screenType.state as SignInState,
+                        onShowPassword = {},
+                        onSignIn = {},
+                        onForgotPassword = {},
+                        onRegistration = {},
+                        modifier = Modifier.padding(horizontal = AppDimensions.paddingMedium)
+                    )
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/ui/AuthorizationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/ui/AuthorizationScreen.kt
@@ -1,10 +1,16 @@
 package io.dimasla4ee.shoppinglist.feature.authorization.ui
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -39,7 +45,10 @@ fun AuthorizationScreen(
         modifier = modifier,
         topBar = {
             Box(
-                modifier = Modifier.fillMaxWidth().padding(vertical = AppDimensions.paddingLarge),
+                modifier = Modifier
+                    .background(MaterialTheme.colorScheme.background)
+                    .fillMaxWidth()
+                    .padding(vertical = AppDimensions.paddingLarge),
                 contentAlignment = Alignment.Center
             ) {
                 Text(
@@ -53,7 +62,14 @@ fun AuthorizationScreen(
 
         },
     ) { paddingValues ->
-        content(paddingValues)
+        Column(
+            modifier = Modifier.fillMaxSize()
+                .imePadding()
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.Center
+        ) {
+            content(paddingValues)
+        }
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/ui/AuthorizationScreenPreviewProvider.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/ui/AuthorizationScreenPreviewProvider.kt
@@ -1,0 +1,49 @@
+package io.dimasla4ee.shoppinglist.feature.authorization.ui
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import io.dimasla4ee.shoppinglist.core.mvi.MviState
+import io.dimasla4ee.shoppinglist.feature.authorization.domain.password_strength_meter.PasswordStrengthLevel
+import io.dimasla4ee.shoppinglist.feature.authorization.domain.password_strength_meter.PasswordStrengthResult
+import io.dimasla4ee.shoppinglist.feature.authorization.presentation.recover_password.RecoverPasswordState
+import io.dimasla4ee.shoppinglist.feature.authorization.presentation.register.RegisterState
+import io.dimasla4ee.shoppinglist.feature.authorization.presentation.sign_in.SignInState
+
+class AuthorizationScreenPreviewProvider : PreviewParameterProvider<AuthorizationScreenType> {
+    override val values: Sequence<AuthorizationScreenType> = sequenceOf(
+        AuthorizationScreenType.SignIn,
+        AuthorizationScreenType.Register,
+        AuthorizationScreenType.RecoverPassword
+    )
+}
+
+sealed class AuthorizationScreenType(
+    open val state: MviState
+) {
+    data object SignIn : AuthorizationScreenType(
+        state = SignInState(
+            email = TextFieldState("test@example.com"),
+            password = TextFieldState("password123"),
+            isPasswordVisible = false
+        )
+    )
+
+    data object Register : AuthorizationScreenType(
+        state = RegisterState(
+            email = TextFieldState("new_user@example.com"),
+            password = TextFieldState("Str0ng!Pass"),
+            isPasswordVisible = false,
+            passwordStrength = PasswordStrengthResult(
+                score = 3,
+                level = PasswordStrengthLevel.Strong,
+                isAcceptable = true
+            )
+        )
+    )
+
+    data object RecoverPassword : AuthorizationScreenType(
+        state = RecoverPasswordState(
+            email = TextFieldState("forgot@example.com")
+        )
+    )
+}


### PR DESCRIPTION
Resolves #74

- Добавлен основной composable-экран `AuthorizationScreen` с Scaffold и общим логотипом в верхней панели
- Создан `AuthorizationScreenPreviewProvider` для превью всех трёх состояний авторизации
- Определён sealed class `AuthorizationScreenType` с тремя data object-состояниями: `SignIn`, `Register`, `RecoverPassword`, каждое из которых хранит соответствующее MviState с предзаполненными тестовыми данными
- `RecoverPasswordState` теперь наследуется от `MviState` для единообразной работы с MVI-архитектурой