### PR TITLE
feat(navigation): Интегрировать экраны авторизации в навигацию

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     alias(libs.plugins.ksp)
     alias(libs.plugins.kotlinSerialization)
     alias(libs.plugins.detekt)
+    alias(libs.plugins.ktorfit)
 }
 
 detekt {

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/di/DataModule.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/di/DataModule.kt
@@ -4,12 +4,12 @@ import androidx.room.RoomDatabase
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import de.jensklingenberg.ktorfit.Ktorfit
 import io.dimasla4ee.shoppinglist.core.data.network.api.AuthApi
-import io.dimasla4ee.shoppinglist.core.domain.repository.AuthRepository
-import io.dimasla4ee.shoppinglist.core.data.repository.AuthRepositoryImpl
 import io.dimasla4ee.shoppinglist.core.data.network.client.KtorfitNetworkClient
 import io.dimasla4ee.shoppinglist.core.data.network.client.NetworkClient
+import io.dimasla4ee.shoppinglist.core.data.repository.AuthRepositoryImpl
 import io.dimasla4ee.shoppinglist.core.database.dao.ShoppingListDao
 import io.dimasla4ee.shoppinglist.core.database.db.ShoppingListDatabase
+import io.dimasla4ee.shoppinglist.core.domain.repository.AuthRepository
 import io.dimasla4ee.shoppinglist.feature.shopping_lists.data.ShoppingListsRepositoryImpl
 import io.dimasla4ee.shoppinglist.feature.shopping_lists.domain.ShoppingListsRepository
 import io.ktor.client.HttpClient

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/di/PresentationModule.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/di/PresentationModule.kt
@@ -2,6 +2,7 @@ package io.dimasla4ee.shoppinglist.app.di
 
 import io.dimasla4ee.shoppinglist.app.navigation.NavigationViewModel
 import io.dimasla4ee.shoppinglist.core.presentation.settings.SettingsViewModel
+import io.dimasla4ee.shoppinglist.feature.authorization.presentation.recover_password.RecoverPasswordViewModel
 import io.dimasla4ee.shoppinglist.feature.authorization.presentation.register.RegisterViewModel
 import io.dimasla4ee.shoppinglist.feature.authorization.presentation.sign_in.SignInViewModel
 import io.dimasla4ee.shoppinglist.feature.products_screen.presentation.model.ProductsViewModel
@@ -37,6 +38,7 @@ val presentationModule = module {
 
     viewModelOf(::SignInViewModel)
     viewModelOf(::RegisterViewModel)
+    viewModelOf(::RecoverPasswordViewModel)
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/di/PresentationModule.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/di/PresentationModule.kt
@@ -1,11 +1,13 @@
 package io.dimasla4ee.shoppinglist.app.di
 
 import io.dimasla4ee.shoppinglist.app.navigation.NavigationViewModel
-import org.koin.core.module.dsl.viewModel
 import io.dimasla4ee.shoppinglist.core.presentation.settings.SettingsViewModel
+import io.dimasla4ee.shoppinglist.feature.authorization.presentation.sign_in.SignInViewModel
 import io.dimasla4ee.shoppinglist.feature.products_screen.presentation.model.ProductsViewModel
 import io.dimasla4ee.shoppinglist.feature.shopping_lists.presentation.ShoppingListsViewModel
 import org.koin.core.module.Module
+import org.koin.core.module.dsl.viewModel
+import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
 /**
@@ -31,6 +33,8 @@ val presentationModule = module {
     }
 
     viewModel { ProductsViewModel() }
+
+    viewModelOf(::SignInViewModel)
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/di/PresentationModule.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/di/PresentationModule.kt
@@ -2,6 +2,7 @@ package io.dimasla4ee.shoppinglist.app.di
 
 import io.dimasla4ee.shoppinglist.app.navigation.NavigationViewModel
 import io.dimasla4ee.shoppinglist.core.presentation.settings.SettingsViewModel
+import io.dimasla4ee.shoppinglist.feature.authorization.presentation.register.RegisterViewModel
 import io.dimasla4ee.shoppinglist.feature.authorization.presentation.sign_in.SignInViewModel
 import io.dimasla4ee.shoppinglist.feature.products_screen.presentation.model.ProductsViewModel
 import io.dimasla4ee.shoppinglist.feature.shopping_lists.presentation.ShoppingListsViewModel
@@ -35,6 +36,7 @@ val presentationModule = module {
     viewModel { ProductsViewModel() }
 
     viewModelOf(::SignInViewModel)
+    viewModelOf(::RegisterViewModel)
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/navigation/EntryProvider.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/navigation/EntryProvider.kt
@@ -1,17 +1,21 @@
 package io.dimasla4ee.shoppinglist.app.navigation
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.sp
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
+import io.dimasla4ee.shoppinglist.feature.authorization.presentation.recover_password.RecoverPasswordEffect
+import io.dimasla4ee.shoppinglist.feature.authorization.presentation.recover_password.RecoverPasswordViewModel
+import io.dimasla4ee.shoppinglist.feature.authorization.presentation.register.RegisterEffect
+import io.dimasla4ee.shoppinglist.feature.authorization.presentation.register.RegisterViewModel
+import io.dimasla4ee.shoppinglist.feature.authorization.presentation.sign_in.SignInEffect
+import io.dimasla4ee.shoppinglist.feature.authorization.presentation.sign_in.SignInViewModel
+import io.dimasla4ee.shoppinglist.feature.authorization.ui.recover_password.RecoverPasswordScreen
+import io.dimasla4ee.shoppinglist.feature.authorization.ui.register.RegisterScreen
+import io.dimasla4ee.shoppinglist.feature.authorization.ui.sign_in.SignInScreen
 import io.dimasla4ee.shoppinglist.feature.products_screen.ui.AddItemScreen
 import io.dimasla4ee.shoppinglist.feature.shopping_lists.presentation.ShoppingListsViewModel
 import io.dimasla4ee.shoppinglist.feature.shopping_lists.ui.screen.ShoppingListsScreen
@@ -82,37 +86,78 @@ fun entryProvider(
     }
 
     entry<Route.Authorization> {
-        // TODO(feature-team): интегрировать экран авторизации и удалить ScreenPlaceholder
-        ScreenPlaceholder("Authorisation")
+        val viewModel = koinViewModel<SignInViewModel>()
+        val state by viewModel.state.collectAsState()
+
+        LaunchedEffect(viewModel) {
+            viewModel.effects.collect { effect ->
+                when (effect) {
+                    SignInEffect.NavigateToMain -> {
+                        topLevelBackStack.replaceStack(Route.ShoppingLists)
+                    }
+
+                    SignInEffect.NavigateToRecoverPassword -> {
+                        topLevelBackStack.add(Route.PasswordRecovery)
+                    }
+
+                    SignInEffect.NavigateToRegister -> {
+                        topLevelBackStack.add(Route.Registration)
+                    }
+                }
+            }
+        }
+
+        SignInScreen(
+            state = state,
+            onIntent = viewModel::dispatch,
+            modifier = Modifier.fillMaxSize()
+        )
     }
 
     entry<Route.Registration> {
-        // TODO(feature-team): интегрировать экран регистрации и удалить ScreenPlaceholder
-        ScreenPlaceholder("Registration")
+        val viewModel = koinViewModel<RegisterViewModel>()
+        val state by viewModel.state.collectAsState()
+
+        LaunchedEffect(viewModel) {
+            viewModel.effects.collect { effect ->
+                when (effect) {
+                    RegisterEffect.NavigateToMain -> {
+                        topLevelBackStack.replaceStack(Route.ShoppingLists)
+                    }
+
+                    RegisterEffect.NavigateToSignIn -> {
+                        topLevelBackStack.removeLast()
+                    }
+                }
+            }
+        }
+
+        RegisterScreen(
+            state = state,
+            onIntent = viewModel::dispatch,
+            modifier = Modifier.fillMaxSize()
+        )
     }
 
     entry<Route.PasswordRecovery> {
-        // TODO(feature-team): интегрировать экран восстановления пароля и удалить ScreenPlaceholder
-        ScreenPlaceholder("PasswordRecovery")
-    }
+        val viewModel = koinViewModel<RecoverPasswordViewModel>()
+        val state by viewModel.state.collectAsState()
 
-}
+        LaunchedEffect(viewModel) {
+            viewModel.effects.collect { effect ->
+                when (effect) {
+                    RecoverPasswordEffect.NavigateToSignIn -> {
+                        topLevelBackStack.removeLast()
+                    }
+                }
+            }
+        }
 
-@Composable
-private fun ScreenPlaceholder(
-    text: String?,
-    modifier: Modifier = Modifier
-) {
-    Box(
-        modifier = modifier
-            .fillMaxSize()
-            .background(Color.Red),
-        contentAlignment = Alignment.Center
-    ) {
-        Text(
-            text = "placeholder\n\n\n$text",
-            fontSize = 50.sp,
-            color = Color.White
+        RecoverPasswordScreen(
+            state = state,
+            onIntent = viewModel::dispatch,
+            modifier = Modifier.fillMaxSize()
         )
     }
+
 }

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/data/network/api/AuthApi.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/data/network/api/AuthApi.kt
@@ -3,6 +3,7 @@ package io.dimasla4ee.shoppinglist.core.data.network.api
 import de.jensklingenberg.ktorfit.http.Body
 import de.jensklingenberg.ktorfit.http.GET
 import de.jensklingenberg.ktorfit.http.Header
+import de.jensklingenberg.ktorfit.http.Headers
 import de.jensklingenberg.ktorfit.http.POST
 import io.dimasla4ee.shoppinglist.core.data.network.dto.Request
 import io.dimasla4ee.shoppinglist.core.domain.model.Response
@@ -24,6 +25,8 @@ interface AuthApi {
          * Базовый префикс для эндпоинтов аутентификации.
          */
         private const val AUTH = "auth"
+        private const val CONTENT_JSON = "Content-Type: application/json"
+        private const val ACCEPT_JSON = "Accept: application/json"
     }
 
     /**
@@ -35,6 +38,7 @@ interface AuthApi {
      * @return данные авторизованного пользователя после успешной регистрации:
      * идентификатор пользователя, access token и refresh token.
      */
+    @Headers(CONTENT_JSON, ACCEPT_JSON)
     @POST("$AUTH/registration")
     suspend fun registerUser(
         @Body request: Request.RegisterRequest
@@ -48,6 +52,7 @@ interface AuthApi {
      * @param request тело запроса, содержащее refresh token.
      * @return новая пара токенов: access token и refresh token.
      */
+    @Headers(CONTENT_JSON, ACCEPT_JSON)
     @POST("$AUTH/refresh")
     suspend fun refresh(
         @Body request: Request.RefreshTokenRequest
@@ -60,6 +65,7 @@ interface AuthApi {
      *
      * @return текстовое сообщение от сервера о результате запуска восстановления.
      */
+    @Headers(ACCEPT_JSON)
     @POST("$AUTH/recovery")
     suspend fun recoverPassword(): Response.RecoverPasswordResponse
 
@@ -72,6 +78,7 @@ interface AuthApi {
      * @return данные авторизации: идентификатор пользователя,
      * access token и refresh token.
      */
+    @Headers(CONTENT_JSON, ACCEPT_JSON)
     @POST("$AUTH/login")
     suspend fun login(
         @Body request: Request.UserAuthRequest
@@ -87,6 +94,7 @@ interface AuthApi {
      * @param authorization значение HTTP-заголовка `Authorization`.
      * @return результат проверки токена.
      */
+    @Headers(ACCEPT_JSON)
     @GET("$AUTH/check")
     suspend fun checkUser(
         @Header("Authorization") authorization: String

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/domain/interactor/LoginUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/domain/interactor/LoginUseCase.kt
@@ -5,6 +5,7 @@ import io.dimasla4ee.shoppinglist.core.domain.model.NetworkError
 import io.dimasla4ee.shoppinglist.core.domain.model.Response
 import io.dimasla4ee.shoppinglist.core.domain.repository.AuthRepository
 
+@Suppress("ForbiddenComment")
 class LoginUseCase(
     private val authRepository: AuthRepository
 ) {

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/domain/interactor/LoginUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/domain/interactor/LoginUseCase.kt
@@ -12,6 +12,7 @@ class LoginUseCase(
         email: String,
         password: String
     ): DomainResult<Response.UserAuthResponse, NetworkError> {
+        // TODO: Сохранение токенов в локальное хранилище после успешной авторизации
         return authRepository.login(email, password)
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/presentation/recover_password/RecoverPasswordState.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/presentation/recover_password/RecoverPasswordState.kt
@@ -5,7 +5,7 @@ import io.dimasla4ee.shoppinglist.core.mvi.MviState
 import io.dimasla4ee.shoppinglist.core.utils.isValidEmail
 
 data class RecoverPasswordState(
-    val email: TextFieldState
+    val email: TextFieldState = TextFieldState()
 ) : MviState {
     val isRecoverEnabled: Boolean
         get() = email.text.isValidEmail()

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/presentation/recover_password/RecoverPasswordViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/presentation/recover_password/RecoverPasswordViewModel.kt
@@ -1,0 +1,53 @@
+package io.dimasla4ee.shoppinglist.feature.authorization.presentation.recover_password
+
+import io.dimasla4ee.shoppinglist.core.domain.interactor.RecoverPasswordUseCase
+import io.dimasla4ee.shoppinglist.core.domain.model.DomainResult
+import io.dimasla4ee.shoppinglist.core.mvi.MviViewModel
+import io.dimasla4ee.shoppinglist.utils.AppLog
+
+@Suppress("ForbiddenComment")
+class RecoverPasswordViewModel(
+    private val recoverPasswordUseCase: RecoverPasswordUseCase
+) : MviViewModel<RecoverPasswordIntent, RecoverPasswordState, RecoverPasswordEffect>(
+    initialState = RecoverPasswordState()
+) {
+
+    override fun reduce(
+        intent: RecoverPasswordIntent,
+        current: RecoverPasswordState
+    ): RecoverPasswordState = when (intent) {
+        RecoverPasswordIntent.RecoverPasswordClicked,
+        RecoverPasswordIntent.CancelClicked -> current
+    }
+
+    override suspend fun handleIntent(intent: RecoverPasswordIntent) {
+        val currentState = state.value
+
+        val effect = when (intent) {
+            RecoverPasswordIntent.CancelClicked -> RecoverPasswordEffect.NavigateToSignIn
+            RecoverPasswordIntent.RecoverPasswordClicked -> handleRecoverPassword(currentState)
+                ?: return
+        }
+
+        emitEffect(effect)
+    }
+
+    private suspend fun handleRecoverPassword(current: RecoverPasswordState): RecoverPasswordEffect? {
+        val email = current.email.text.toString().trim()
+
+        // TODO: Показывать snackbar / ошибки валидации
+        if (email.isBlank() || !current.isRecoverEnabled) return null
+
+        val result = recoverPasswordUseCase.invoke()
+
+        AppLog.d("RecoverPasswordVM", result.toString())
+
+        return when (result) {
+            is DomainResult.Error<*> -> null
+            is DomainResult.Success<*> -> {
+                // TODO: Показать сообщение об успешной отправке письма
+                RecoverPasswordEffect.NavigateToSignIn
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/presentation/register/RegisterState.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/presentation/register/RegisterState.kt
@@ -3,19 +3,25 @@ package io.dimasla4ee.shoppinglist.feature.authorization.presentation.register
 import androidx.compose.foundation.text.input.TextFieldState
 import io.dimasla4ee.shoppinglist.core.mvi.MviState
 import io.dimasla4ee.shoppinglist.core.utils.isValidEmail
-import io.dimasla4ee.shoppinglist.feature.authorization.domain.password_strength_meter.PasswordStrengthLevel
+import io.dimasla4ee.shoppinglist.feature.authorization.domain.password_strength_meter.PasswordEstimator
+import io.dimasla4ee.shoppinglist.feature.authorization.domain.password_strength_meter.PasswordStrengthMapper
 import io.dimasla4ee.shoppinglist.feature.authorization.domain.password_strength_meter.PasswordStrengthResult
 
 data class RegisterState(
     val email: TextFieldState = TextFieldState(),
     val password: TextFieldState = TextFieldState(),
-    val isPasswordVisible: Boolean = false,
-    val passwordStrength: PasswordStrengthResult = PasswordStrengthResult(
-        score = 0,
-        level = PasswordStrengthLevel.Empty,
-        isAcceptable = false
-    )
+    val isPasswordVisible: Boolean = false
 ) : MviState {
+    private val passwordEstimator = PasswordEstimator()
+    val passwordStrength: PasswordStrengthResult
+        get() {
+            val passwordStr = password.text.toString()
+            return PasswordStrengthMapper.fromScore(
+                score = passwordEstimator.estimate(passwordStr),
+                password = passwordStr
+            )
+        }
+
     val isRegisterAllowed: Boolean
         get() = passwordStrength.isAcceptable && email.text.isValidEmail()
 }

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/presentation/register/RegisterViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/presentation/register/RegisterViewModel.kt
@@ -1,0 +1,59 @@
+package io.dimasla4ee.shoppinglist.feature.authorization.presentation.register
+
+import io.dimasla4ee.shoppinglist.core.domain.interactor.RegisterUseCase
+import io.dimasla4ee.shoppinglist.core.domain.model.DomainResult
+import io.dimasla4ee.shoppinglist.core.mvi.MviViewModel
+import io.dimasla4ee.shoppinglist.utils.AppLog
+
+class RegisterViewModel(
+    private val registerUseCase: RegisterUseCase
+) : MviViewModel<RegisterIntent, RegisterState, RegisterEffect>(
+    initialState = RegisterState()
+) {
+
+    override fun reduce(
+        intent: RegisterIntent,
+        current: RegisterState
+    ): RegisterState = when (intent) {
+        RegisterIntent.PasswordVisibilityToggleClicked -> {
+            current.copy(
+                isPasswordVisible = !current.isPasswordVisible
+            )
+        }
+
+        RegisterIntent.RegisterClicked,
+        RegisterIntent.SignInClicked -> current
+    }
+
+    override suspend fun handleIntent(intent: RegisterIntent) {
+        val currentState = state.value
+
+        AppLog.d("RegisterVM", state.value.toString())
+
+        val effect = when (intent) {
+            RegisterIntent.SignInClicked -> RegisterEffect.NavigateToSignIn
+            RegisterIntent.RegisterClicked -> handleRegister(currentState) ?: return
+            RegisterIntent.PasswordVisibilityToggleClicked -> return
+        }
+
+        emitEffect(effect)
+    }
+
+    private suspend fun handleRegister(current: RegisterState): RegisterEffect? {
+        val email = current.email.text.toString().trim()
+        val password = current.password.text.toString()
+
+        // TODO: Показывать snackbar / ошибки валидации
+        if (email.isBlank() || password.isBlank()) return null
+        if (!current.isRegisterAllowed) return null
+
+        val result = registerUseCase.invoke(email, password)
+
+        AppLog.d("RegisterVM", result.toString())
+
+        return when (result) {
+            is DomainResult.Error<*> -> null
+            is DomainResult.Success<*> -> RegisterEffect.NavigateToMain
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/presentation/register/RegisterViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/presentation/register/RegisterViewModel.kt
@@ -5,6 +5,7 @@ import io.dimasla4ee.shoppinglist.core.domain.model.DomainResult
 import io.dimasla4ee.shoppinglist.core.mvi.MviViewModel
 import io.dimasla4ee.shoppinglist.utils.AppLog
 
+@Suppress("ForbiddenComment")
 class RegisterViewModel(
     private val registerUseCase: RegisterUseCase
 ) : MviViewModel<RegisterIntent, RegisterState, RegisterEffect>(
@@ -44,8 +45,7 @@ class RegisterViewModel(
         val password = current.password.text.toString()
 
         // TODO: Показывать snackbar / ошибки валидации
-        if (email.isBlank() || password.isBlank()) return null
-        if (!current.isRegisterAllowed) return null
+        if (email.isBlank() || password.isBlank() || !current.isRegisterAllowed) return null
 
         val result = registerUseCase.invoke(email, password)
 

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/presentation/sign_in/SignInViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/presentation/sign_in/SignInViewModel.kt
@@ -5,6 +5,7 @@ import io.dimasla4ee.shoppinglist.core.domain.model.DomainResult
 import io.dimasla4ee.shoppinglist.core.mvi.MviViewModel
 import io.dimasla4ee.shoppinglist.utils.AppLog
 
+@Suppress("ForbiddenComment")
 class SignInViewModel(
     val loginUseCase: LoginUseCase
 ) : MviViewModel<SignInIntent, SignInState, SignInEffect>(

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/presentation/sign_in/SignInViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/presentation/sign_in/SignInViewModel.kt
@@ -1,0 +1,55 @@
+package io.dimasla4ee.shoppinglist.feature.authorization.presentation.sign_in
+
+import io.dimasla4ee.shoppinglist.core.domain.interactor.LoginUseCase
+import io.dimasla4ee.shoppinglist.core.domain.model.DomainResult
+import io.dimasla4ee.shoppinglist.core.mvi.MviViewModel
+import io.dimasla4ee.shoppinglist.utils.AppLog
+
+class SignInViewModel(
+    val loginUseCase: LoginUseCase
+) : MviViewModel<SignInIntent, SignInState, SignInEffect>(
+    initialState = SignInState()
+) {
+    override fun reduce(
+        intent: SignInIntent,
+        current: SignInState
+    ): SignInState = when (intent) {
+        SignInIntent.PasswordVisibilityToggleClicked -> {
+            current.copy(
+                isPasswordVisible = !current.isPasswordVisible
+            )
+        }
+
+        SignInIntent.ForgotPasswordClicked,
+        SignInIntent.SignInClicked,
+        SignInIntent.SignUpClicked -> current
+    }
+
+    override suspend fun handleIntent(intent: SignInIntent) {
+        val currentState = state.value
+
+        val effect = when (intent) {
+            SignInIntent.ForgotPasswordClicked -> SignInEffect.NavigateToRecoverPassword
+            SignInIntent.SignInClicked -> handleSignIn(currentState) ?: return
+            SignInIntent.SignUpClicked -> SignInEffect.NavigateToRegister
+            SignInIntent.PasswordVisibilityToggleClicked -> return
+        }
+        emitEffect(effect)
+    }
+
+    private suspend fun handleSignIn(current: SignInState): SignInEffect? {
+        val email = current.email.text.toString()
+        val password = current.password.text.toString()
+
+        // TODO: Показывать снэкбар для обработки ошибок
+        if (email.isBlank() || password.isBlank()) return null
+
+        val result = loginUseCase.invoke(email, password)
+
+        AppLog.d("VM", result.toString())
+        return when (result) {
+            is DomainResult.Error<*> -> null
+            is DomainResult.Success<*> -> SignInEffect.NavigateToMain
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/ui/AuthorizationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/ui/AuthorizationScreen.kt
@@ -3,11 +3,11 @@ package io.dimasla4ee.shoppinglist.feature.authorization.ui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -37,9 +37,10 @@ import io.dimasla4ee.shoppinglist.feature.welcome_screen.ui.createWelcomeLogo
 @Composable
 fun AuthorizationScreen(
     modifier: Modifier = Modifier,
-    content: @Composable (PaddingValues) -> Unit
+    content: @Composable () -> Unit
 ) {
     val (annotatedString, inlineContentMap) = createWelcomeLogo()
+    val scrollState = rememberScrollState()
 
     Scaffold(
         modifier = modifier,
@@ -59,16 +60,23 @@ fun AuthorizationScreen(
                     textAlign = TextAlign.Center
                 )
             }
-
-        },
+        }
     ) { paddingValues ->
-        Column(
-            modifier = Modifier.fillMaxSize()
-                .imePadding()
-                .verticalScroll(rememberScrollState()),
-            verticalArrangement = Arrangement.Center
+        BoxWithConstraints(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
         ) {
-            content(paddingValues)
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .defaultMinSize(minHeight = maxHeight)
+                    .verticalScroll(scrollState),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                content()
+            }
         }
     }
 }
@@ -79,43 +87,36 @@ fun AuthorizationScreen(
 private fun AuthorizationScreenPreview(
     @PreviewParameter(AuthorizationScreenPreviewProvider::class) screenType: AuthorizationScreenType
 ) = ShoppingListTheme {
-    AuthorizationScreen(Modifier.fillMaxSize()) { paddingValues ->
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues),
-            contentAlignment = Alignment.Center
-        ) {
-            when (screenType) {
-                AuthorizationScreenType.RecoverPassword -> {
-                    RecoverPasswordContent(
-                        state = screenType.state as RecoverPasswordState,
-                        onRecoverPassword = {},
-                        onCancel = {},
-                        modifier = Modifier.padding(horizontal = AppDimensions.paddingMedium)
-                    )
-                }
+    AuthorizationScreen(Modifier.fillMaxSize()) {
+        when (screenType) {
+            AuthorizationScreenType.RecoverPassword -> {
+                RecoverPasswordContent(
+                    state = screenType.state as RecoverPasswordState,
+                    onRecoverPassword = {},
+                    onCancel = {},
+                    modifier = Modifier.padding(horizontal = AppDimensions.paddingMedium)
+                )
+            }
 
-                AuthorizationScreenType.Register -> {
-                    RegisterContent(
-                        state = screenType.state as RegisterState,
-                        onShowPassword = {},
-                        onRegister = {},
-                        onAuthorization = {},
-                        modifier = Modifier.padding(horizontal = AppDimensions.paddingMedium)
-                    )
-                }
+            AuthorizationScreenType.Register -> {
+                RegisterContent(
+                    state = screenType.state as RegisterState,
+                    onShowPassword = {},
+                    onRegister = {},
+                    onAuthorization = {},
+                    modifier = Modifier.padding(horizontal = AppDimensions.paddingMedium)
+                )
+            }
 
-                AuthorizationScreenType.SignIn -> {
-                    SignInContent(
-                        state = screenType.state as SignInState,
-                        onShowPassword = {},
-                        onSignIn = {},
-                        onForgotPassword = {},
-                        onRegistration = {},
-                        modifier = Modifier.padding(horizontal = AppDimensions.paddingMedium)
-                    )
-                }
+            AuthorizationScreenType.SignIn -> {
+                SignInContent(
+                    state = screenType.state as SignInState,
+                    onShowPassword = {},
+                    onSignIn = {},
+                    onForgotPassword = {},
+                    onRegistration = {},
+                    modifier = Modifier.padding(horizontal = AppDimensions.paddingMedium)
+                )
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/ui/AuthorizationScreenPreviewProvider.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/ui/AuthorizationScreenPreviewProvider.kt
@@ -3,8 +3,6 @@ package io.dimasla4ee.shoppinglist.feature.authorization.ui
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import io.dimasla4ee.shoppinglist.core.mvi.MviState
-import io.dimasla4ee.shoppinglist.feature.authorization.domain.password_strength_meter.PasswordStrengthLevel
-import io.dimasla4ee.shoppinglist.feature.authorization.domain.password_strength_meter.PasswordStrengthResult
 import io.dimasla4ee.shoppinglist.feature.authorization.presentation.recover_password.RecoverPasswordState
 import io.dimasla4ee.shoppinglist.feature.authorization.presentation.register.RegisterState
 import io.dimasla4ee.shoppinglist.feature.authorization.presentation.sign_in.SignInState
@@ -32,12 +30,7 @@ sealed class AuthorizationScreenType(
         state = RegisterState(
             email = TextFieldState("new_user@example.com"),
             password = TextFieldState("Str0ng!Pass"),
-            isPasswordVisible = false,
-            passwordStrength = PasswordStrengthResult(
-                score = 3,
-                level = PasswordStrengthLevel.Strong,
-                isAcceptable = true
-            )
+            isPasswordVisible = false
         )
     )
 

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/ui/recover_password/RecoverPasswordContent.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/ui/recover_password/RecoverPasswordContent.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -56,9 +57,11 @@ fun RecoverPasswordContent(
             )
 
             Text(
+                modifier = Modifier.appDefaultFormSize(),
                 text = stringResource(Res.string.authorization_recover_password_description),
                 style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
             )
         }
 
@@ -106,3 +109,4 @@ private fun RecoverPasswordContentPreview(
         )
     }
 }
+

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/ui/recover_password/RecoverPasswordScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/ui/recover_password/RecoverPasswordScreen.kt
@@ -1,0 +1,32 @@
+package io.dimasla4ee.shoppinglist.feature.authorization.ui.recover_password
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import io.dimasla4ee.shoppinglist.app.ui.theme.AppDimensions
+import io.dimasla4ee.shoppinglist.feature.authorization.presentation.recover_password.RecoverPasswordIntent
+import io.dimasla4ee.shoppinglist.feature.authorization.presentation.recover_password.RecoverPasswordState
+import io.dimasla4ee.shoppinglist.feature.authorization.ui.AuthorizationScreen
+
+@Composable
+fun RecoverPasswordScreen(
+    state: RecoverPasswordState,
+    onIntent: (RecoverPasswordIntent) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    AuthorizationScreen(
+        modifier = modifier.fillMaxSize()
+    ) {
+        RecoverPasswordContent(
+            state = state,
+            onRecoverPassword = {
+                onIntent(RecoverPasswordIntent.RecoverPasswordClicked)
+            },
+            onCancel = {
+                onIntent(RecoverPasswordIntent.CancelClicked)
+            },
+            modifier = Modifier.padding(horizontal = AppDimensions.paddingMedium)
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/ui/register/RegisterContent.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/ui/register/RegisterContent.kt
@@ -131,4 +131,3 @@ private fun PreviewRegisterContent(
         )
     }
 }
-

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/ui/register/RegisterInfoProvider.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/ui/register/RegisterInfoProvider.kt
@@ -3,13 +3,9 @@ package io.dimasla4ee.shoppinglist.feature.authorization.ui.register
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import io.dimasla4ee.shoppinglist.core.presentation.preview.AuthorizationPreviewHelper
-import io.dimasla4ee.shoppinglist.feature.authorization.domain.password_strength_meter.PasswordEstimator
-import io.dimasla4ee.shoppinglist.feature.authorization.domain.password_strength_meter.PasswordStrengthMapper
 import io.dimasla4ee.shoppinglist.feature.authorization.presentation.register.RegisterState
 
 class RegisterInfoProvider : PreviewParameterProvider<RegisterState> {
-
-    private val passwordEstimator = PasswordEstimator()
 
     override val values: Sequence<RegisterState>
         get() {
@@ -33,17 +29,10 @@ class RegisterInfoProvider : PreviewParameterProvider<RegisterState> {
         password: String,
         isPasswordVisible: Boolean
     ): RegisterState {
-        val rawScore = passwordEstimator.estimate(password)
-        val passwordStrength = PasswordStrengthMapper.fromScore(
-            score = rawScore,
-            password = password
-        )
-
         return RegisterState(
             email = TextFieldState(email),
             password = TextFieldState(password),
-            isPasswordVisible = isPasswordVisible,
-            passwordStrength = passwordStrength
+            isPasswordVisible = isPasswordVisible
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/ui/register/RegisterScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/ui/register/RegisterScreen.kt
@@ -1,0 +1,35 @@
+package io.dimasla4ee.shoppinglist.feature.authorization.ui.register
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import io.dimasla4ee.shoppinglist.app.ui.theme.AppDimensions
+import io.dimasla4ee.shoppinglist.feature.authorization.presentation.register.RegisterIntent
+import io.dimasla4ee.shoppinglist.feature.authorization.presentation.register.RegisterState
+import io.dimasla4ee.shoppinglist.feature.authorization.ui.AuthorizationScreen
+
+@Composable
+fun RegisterScreen(
+    state: RegisterState,
+    onIntent: (RegisterIntent) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    AuthorizationScreen(
+        modifier = modifier.fillMaxSize()
+    ) {
+        RegisterContent(
+            state = state,
+            onShowPassword = {
+                onIntent(RegisterIntent.PasswordVisibilityToggleClicked)
+            },
+            onRegister = {
+                onIntent(RegisterIntent.RegisterClicked)
+            },
+            onAuthorization = {
+                onIntent(RegisterIntent.SignInClicked)
+            },
+            modifier = Modifier.padding(horizontal = AppDimensions.paddingMedium)
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/ui/sign_in/SignInScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/ui/sign_in/SignInScreen.kt
@@ -1,0 +1,38 @@
+package io.dimasla4ee.shoppinglist.feature.authorization.ui.sign_in
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import io.dimasla4ee.shoppinglist.app.ui.theme.AppDimensions
+import io.dimasla4ee.shoppinglist.feature.authorization.presentation.sign_in.SignInIntent
+import io.dimasla4ee.shoppinglist.feature.authorization.presentation.sign_in.SignInState
+import io.dimasla4ee.shoppinglist.feature.authorization.ui.AuthorizationScreen
+
+@Composable
+fun SignInScreen(
+    state: SignInState,
+    onIntent: (SignInIntent) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    AuthorizationScreen(
+        modifier = modifier.fillMaxSize()
+    ) {
+        SignInContent(
+            state = state,
+            onShowPassword = {
+                onIntent(SignInIntent.PasswordVisibilityToggleClicked)
+            },
+            onSignIn = {
+                onIntent(SignInIntent.SignInClicked)
+            },
+            onForgotPassword = {
+                onIntent(SignInIntent.ForgotPasswordClicked)
+            },
+            onRegistration = {
+                onIntent(SignInIntent.SignUpClicked)
+            },
+            modifier = Modifier.padding(horizontal = AppDimensions.paddingMedium)
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -138,3 +138,4 @@ composeHotReload = { id = "org.jetbrains.compose.hot-reload", version.ref = "com
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 detekt = { id = "dev.detekt", version.ref = "detekt" }
+ktorfit = { id = "de.jensklingenberg.ktorfit", version.ref = "ktorfit" }


### PR DESCRIPTION
Resolves #72

- Заменены заглушки на `SignInScreen`, `RegisterScreen` и `RecoverPasswordScreen`
- Реализована интеграция `ViewModel` и обработка сайд-эффектов для маршрутов авторизации
- Удалён временный composable `ScreenPlaceholder`