### PR TITLE
feature/129-отслеживать-вид-сортировки-через-локальное-хранилище-datastore

### DIFF
--- a/composeApp/src/androidMain/kotlin/io/dimasla4ee/shoppinglist/app/data/database/SettingsDataSource.kt
+++ b/composeApp/src/androidMain/kotlin/io/dimasla4ee/shoppinglist/app/data/database/SettingsDataSource.kt
@@ -4,6 +4,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import io.dimasla4ee.shoppinglist.app.ui.theme.ThemeMode
+import io.dimasla4ee.shoppinglist.feature.products_screen.domain.SortMode
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -14,6 +15,7 @@ class SettingsDataSource(
 
     companion object {
         private val THEME_KEY = stringPreferencesKey("theme_mode")
+        private fun sortModeKey(listId: Long) = stringPreferencesKey("sort_mode_$listId")
     }
 
     fun observeThemeMode(): Flow<ThemeMode> = dataStore.data
@@ -34,5 +36,29 @@ class SettingsDataSource(
         val preferences = dataStore.data.first()
         val value = preferences[THEME_KEY] ?: ThemeMode.SYSTEM.name
         return ThemeMode.valueOf(value)
+    }
+
+    fun observeSortMode(listId: Long): Flow<SortMode> = dataStore.data
+        .map { preferences ->
+            val key = sortModeKey(listId)
+            val value = preferences[key] ?: SortMode.CUSTOM.name
+            SortMode.valueOf(value)
+        }
+
+    suspend fun setSortMode(listId: Long, mode: SortMode) {
+        dataStore.updateData { preferences ->
+            preferences.toMutablePreferences().apply {
+                val key = sortModeKey(listId)
+                this[key] = mode.name
+            }
+        }
+    }
+
+    suspend fun removeSortMode(listId: Long) {
+        dataStore.updateData { preferences ->
+            preferences.toMutablePreferences().apply {
+                remove(sortModeKey(listId))
+            }
+        }
     }
 }

--- a/composeApp/src/androidMain/kotlin/io/dimasla4ee/shoppinglist/app/data/repository/SettingsRepositoryImpl.kt
+++ b/composeApp/src/androidMain/kotlin/io/dimasla4ee/shoppinglist/app/data/repository/SettingsRepositoryImpl.kt
@@ -3,6 +3,7 @@ package io.dimasla4ee.shoppinglist.app.data.repository
 import io.dimasla4ee.shoppinglist.app.data.database.SettingsDataSource
 import io.dimasla4ee.shoppinglist.app.ui.theme.ThemeMode
 import io.dimasla4ee.shoppinglist.core.domain.repository.SettingsRepository
+import io.dimasla4ee.shoppinglist.feature.products_screen.domain.SortMode
 import kotlinx.coroutines.flow.Flow
 
 class SettingsRepositoryImpl(
@@ -15,4 +16,16 @@ class SettingsRepositoryImpl(
     override suspend fun setThemeMode(mode: ThemeMode) {
         dataSource.setThemeMode(mode)
     }
+
+    override fun observeSortMode(listId: Long): Flow<SortMode> =
+        dataSource.observeSortMode(listId)
+
+    override suspend fun setSortMode(listId: Long, mode: SortMode) {
+        dataSource.setSortMode(listId, mode)
+    }
+
+    override suspend fun removeSortMode(listId: Long) {
+        dataSource.removeSortMode(listId)
+    }
 }
+

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/di/DomainModule.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/di/DomainModule.kt
@@ -7,12 +7,16 @@ import io.dimasla4ee.shoppinglist.core.domain.interactor.RecoverPasswordUseCase
 import io.dimasla4ee.shoppinglist.core.domain.interactor.RefreshTokenUseCase
 import io.dimasla4ee.shoppinglist.core.domain.interactor.RegisterUseCase
 import io.dimasla4ee.shoppinglist.core.domain.interactor.ToggleThemeInteractor
+import io.dimasla4ee.shoppinglist.core.domain.interactor.sorting.GetSortModeUseCase
+import io.dimasla4ee.shoppinglist.core.domain.interactor.sorting.RemoveSortModeUseCase
+import io.dimasla4ee.shoppinglist.core.domain.interactor.sorting.SetSortModeUseCase
 import io.dimasla4ee.shoppinglist.core.domain.repository.AuthRepository
 import io.dimasla4ee.shoppinglist.core.domain.repository.SettingsRepository
 import io.dimasla4ee.shoppinglist.feature.shopping_lists.domain.ShoppingListsInteractor
 import io.dimasla4ee.shoppinglist.feature.shopping_lists.domain.ShoppingListsInteractorImpl
 import io.dimasla4ee.shoppinglist.feature.shopping_lists.domain.ShoppingListsRepository
 import org.koin.core.module.Module
+import org.koin.core.module.dsl.factoryOf
 import org.koin.dsl.module
 
 /**
@@ -67,6 +71,10 @@ val domainModule = module {
             authRepository = get<AuthRepository>()
         )
     }
+
+    factoryOf(::SetSortModeUseCase)
+    factoryOf(::GetSortModeUseCase)
+    factoryOf(::RemoveSortModeUseCase)
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/di/PresentationModule.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/di/PresentationModule.kt
@@ -28,12 +28,7 @@ val presentationModule = module {
         )
     }
 
-    viewModel {
-        ShoppingListsViewModel(
-            interactor = get()
-        )
-    }
-
+    viewModelOf(::ShoppingListsViewModel)
     viewModelOf(::ProductsViewModel)
     viewModelOf(::SignInViewModel)
     viewModelOf(::RegisterViewModel)

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/di/PresentationModule.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/di/PresentationModule.kt
@@ -28,16 +28,13 @@ val presentationModule = module {
         )
     }
 
-    viewModel<ProductsViewModel> { ProductsViewModel() }
-
     viewModel {
         ShoppingListsViewModel(
             interactor = get()
         )
     }
 
-    viewModel { ProductsViewModel() }
-
+    viewModelOf(::ProductsViewModel)
     viewModelOf(::SignInViewModel)
     viewModelOf(::RegisterViewModel)
     viewModelOf(::RecoverPasswordViewModel)

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/navigation/EntryProvider.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/navigation/EntryProvider.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
@@ -18,7 +17,6 @@ import io.dimasla4ee.shoppinglist.feature.authorization.ui.recover_password.Reco
 import io.dimasla4ee.shoppinglist.feature.authorization.ui.register.RegisterScreen
 import io.dimasla4ee.shoppinglist.feature.authorization.ui.sign_in.SignInScreen
 import io.dimasla4ee.shoppinglist.feature.products_screen.ui.AddItemRoute
-import io.dimasla4ee.shoppinglist.feature.products_screen.ui.AddItemScreen
 import io.dimasla4ee.shoppinglist.feature.shopping_lists.presentation.ShoppingListsEffect
 import io.dimasla4ee.shoppinglist.feature.shopping_lists.presentation.ShoppingListsIntent
 import io.dimasla4ee.shoppinglist.feature.shopping_lists.presentation.ShoppingListsViewModel
@@ -76,6 +74,7 @@ fun entryProvider(
     entry<Route.ProductsList> { route ->
 
         AddItemRoute(
+            listId = route.listId,
             listName = route.listName,
             onMenuClick = {},
             onBackClick = {

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/domain/interactor/sorting/GetSortModeUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/domain/interactor/sorting/GetSortModeUseCase.kt
@@ -1,0 +1,12 @@
+package io.dimasla4ee.shoppinglist.core.domain.interactor.sorting
+
+import io.dimasla4ee.shoppinglist.core.domain.repository.SettingsRepository
+import io.dimasla4ee.shoppinglist.feature.products_screen.domain.SortMode
+import kotlinx.coroutines.flow.Flow
+
+class GetSortModeUseCase(
+    private val settingsRepository: SettingsRepository
+) {
+    operator fun invoke(listId: Long): Flow<SortMode> =
+        settingsRepository.observeSortMode(listId)
+}

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/domain/interactor/sorting/RemoveSortModeUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/domain/interactor/sorting/RemoveSortModeUseCase.kt
@@ -1,0 +1,11 @@
+package io.dimasla4ee.shoppinglist.core.domain.interactor.sorting
+
+import io.dimasla4ee.shoppinglist.core.domain.repository.SettingsRepository
+
+class RemoveSortModeUseCase(
+    private val settingsRepository: SettingsRepository
+) {
+    suspend operator fun invoke(listId: Long) {
+        settingsRepository.removeSortMode(listId)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/domain/interactor/sorting/SetSortModeUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/domain/interactor/sorting/SetSortModeUseCase.kt
@@ -1,0 +1,12 @@
+package io.dimasla4ee.shoppinglist.core.domain.interactor.sorting
+
+import io.dimasla4ee.shoppinglist.core.domain.repository.SettingsRepository
+import io.dimasla4ee.shoppinglist.feature.products_screen.domain.SortMode
+
+class SetSortModeUseCase(
+    private val settingsRepository: SettingsRepository
+) {
+    suspend operator fun invoke(listId: Long, mode: SortMode) {
+        settingsRepository.setSortMode(listId, mode)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/domain/repository/SettingsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/domain/repository/SettingsRepository.kt
@@ -1,6 +1,7 @@
 package io.dimasla4ee.shoppinglist.core.domain.repository
 
 import io.dimasla4ee.shoppinglist.app.ui.theme.ThemeMode
+import io.dimasla4ee.shoppinglist.feature.products_screen.domain.SortMode
 import kotlinx.coroutines.flow.Flow
 
 interface SettingsRepository {
@@ -8,4 +9,8 @@ interface SettingsRepository {
     val themeMode: Flow<ThemeMode>
 
     suspend fun setThemeMode(mode: ThemeMode)
+
+    fun observeSortMode(listId: Long): Flow<SortMode>
+    suspend fun setSortMode(listId: Long, mode: SortMode)
+    suspend fun removeSortMode(listId: Long)
 }

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/products_screen/domain/SortMode.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/products_screen/domain/SortMode.kt
@@ -1,0 +1,6 @@
+package io.dimasla4ee.shoppinglist.feature.products_screen.domain
+
+enum class SortMode {
+    CUSTOM,
+    ALPHABETICAL
+}

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/products_screen/presentation/model/AddProductUiState.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/products_screen/presentation/model/AddProductUiState.kt
@@ -3,6 +3,7 @@ package io.dimasla4ee.shoppinglist.feature.products_screen.presentation.model
 import io.dimasla4ee.shoppinglist.core.domain.model.MeasurementUnit
 import io.dimasla4ee.shoppinglist.core.domain.model.Product
 import io.dimasla4ee.shoppinglist.core.mvi.MviState
+import io.dimasla4ee.shoppinglist.feature.products_screen.domain.SortMode
 
 data class AddProductUiState(
     val name: String = "",

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/products_screen/presentation/model/ProductsIntent.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/products_screen/presentation/model/ProductsIntent.kt
@@ -1,6 +1,7 @@
 package io.dimasla4ee.shoppinglist.feature.products_screen.presentation.model
 
 import io.dimasla4ee.shoppinglist.core.domain.model.MeasurementUnit
+import io.dimasla4ee.shoppinglist.core.domain.model.Product
 import io.dimasla4ee.shoppinglist.core.mvi.MviIntent
 
 sealed interface ProductsIntent : MviIntent {
@@ -14,7 +15,7 @@ sealed interface ProductsIntent : MviIntent {
     data object AddItem : ProductsIntent
 
     data object ToggleBottomSheet : ProductsIntent
-    data class ToggleItemChecked(val id: Long) : ProductsIntent
+    data class ToggleItemChecked(val product: Product) : ProductsIntent
 
     data class ReorderProduct(
         val fromIndex: Int,

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/products_screen/presentation/model/ProductsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/products_screen/presentation/model/ProductsViewModel.kt
@@ -104,20 +104,12 @@ class ProductsViewModel(
             }
 
             is ProductsIntent.ToggleItemChecked -> {
-
-                updateState { current ->
-                    current.copy(
-                        items = current.items.map { item ->
-                            if (item.id == intent.id) {
-                                item.copy(
-                                    isChecked = !item.isChecked
-                                )
-                            } else {
-                                item
-                            }
-                        }
-                    )
+                val products = state.value.items.toMutableList().apply {
+                    remove(intent.product)
+                    add(intent.product.copy(isChecked = !intent.product.isChecked))
                 }
+
+                updateState { it.copy(items = products) }
             }
 
             ProductsIntent.ToggleSortMode -> {

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/products_screen/presentation/model/ProductsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/products_screen/presentation/model/ProductsViewModel.kt
@@ -3,6 +3,7 @@ package io.dimasla4ee.shoppinglist.feature.products_screen.presentation.model
 import io.dimasla4ee.shoppinglist.core.domain.model.MeasurementUnit
 import io.dimasla4ee.shoppinglist.core.domain.model.Product
 import io.dimasla4ee.shoppinglist.core.mvi.MviViewModel
+import io.dimasla4ee.shoppinglist.feature.products_screen.domain.SortMode
 
 class ProductsViewModel :
     MviViewModel<ProductsIntent, AddProductUiState, ProductsEffect>(

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/products_screen/presentation/model/ProductsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/products_screen/presentation/model/ProductsViewModel.kt
@@ -1,14 +1,31 @@
 package io.dimasla4ee.shoppinglist.feature.products_screen.presentation.model
 
+import androidx.lifecycle.viewModelScope
+import io.dimasla4ee.shoppinglist.core.domain.interactor.sorting.GetSortModeUseCase
+import io.dimasla4ee.shoppinglist.core.domain.interactor.sorting.SetSortModeUseCase
 import io.dimasla4ee.shoppinglist.core.domain.model.MeasurementUnit
 import io.dimasla4ee.shoppinglist.core.domain.model.Product
 import io.dimasla4ee.shoppinglist.core.mvi.MviViewModel
 import io.dimasla4ee.shoppinglist.feature.products_screen.domain.SortMode
+import kotlinx.coroutines.launch
 
-class ProductsViewModel :
-    MviViewModel<ProductsIntent, AddProductUiState, ProductsEffect>(
-        AddProductUiState()
-    ) {
+class ProductsViewModel(
+    val getSortModeUseCase: GetSortModeUseCase,
+    val setSortModeUseCase: SetSortModeUseCase
+) : MviViewModel<ProductsIntent, AddProductUiState, ProductsEffect>(
+    initialState = AddProductUiState()
+) {
+
+    private var listId: Long = 0
+
+    fun getSortMode(listId: Long) {
+        this.listId = listId
+        viewModelScope.launch {
+            getSortModeUseCase(listId).collect { mode ->
+                updateState { it.copy(sortMode = mode) }
+            }
+        }
+    }
 
     override fun reduce(intent: ProductsIntent, current: AddProductUiState): AddProductUiState {
         return when (intent) {
@@ -38,8 +55,9 @@ class ProductsViewModel :
                 )
 
             is ProductsIntent.ReorderProduct -> {
-                val items = current.items.toMutableList()
+                if (current.sortMode != SortMode.CUSTOM) return current
 
+                val items = current.items.toMutableList()
                 items.removeAt(intent.fromIndex).let { movedItem ->
                     items.add(intent.toIndex, movedItem)
                 }
@@ -51,14 +69,7 @@ class ProductsViewModel :
                 current.copy(items = reordered)
             }
 
-            ProductsIntent.ToggleSortMode -> {
-                val newMode = when (current.sortMode) {
-                    SortMode.CUSTOM -> SortMode.ALPHABETICAL
-                    SortMode.ALPHABETICAL -> SortMode.CUSTOM
-                }
-                current.copy(sortMode = newMode)
-            }
-
+            ProductsIntent.ToggleSortMode,
             ProductsIntent.AddItem,
             is ProductsIntent.ToggleItemChecked -> current
         }
@@ -69,7 +80,6 @@ class ProductsViewModel :
         when (intent) {
 
             ProductsIntent.AddItem -> {
-
                 val currentState = state.value
 
                 if (currentState.name.isBlank()) return
@@ -110,7 +120,15 @@ class ProductsViewModel :
                 }
             }
 
-            ProductsIntent.ToggleBottomSheet -> Unit
+            ProductsIntent.ToggleSortMode -> {
+                val currentMode = state.value.sortMode
+                val newMode = when (currentMode) {
+                    SortMode.CUSTOM -> SortMode.ALPHABETICAL
+                    SortMode.ALPHABETICAL -> SortMode.CUSTOM
+                }
+                setSortModeUseCase(listId, newMode)
+            }
+
             else -> Unit
         }
     }

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/products_screen/presentation/model/SortMode.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/products_screen/presentation/model/SortMode.kt
@@ -1,6 +1,0 @@
-package io.dimasla4ee.shoppinglist.feature.products_screen.presentation.model
-
-enum class SortMode {
-    CUSTOM,
-    ALPHABETICAL
-}

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/products_screen/ui/AddItemRoute.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/products_screen/ui/AddItemRoute.kt
@@ -1,6 +1,7 @@
 package io.dimasla4ee.shoppinglist.feature.products_screen.ui
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.dimasla4ee.shoppinglist.feature.products_screen.presentation.model.ProductsViewModel
@@ -10,13 +11,17 @@ import org.koin.compose.viewmodel.koinViewModel
 @Composable
 fun AddItemRoute(
     listName: String,
+    listId: Long,
     onMenuClick: () -> Unit,
     onBackClick: () -> Unit,
     viewModel: ProductsViewModel = koinViewModel()
 ) {
-
     val state by viewModel.state.collectAsStateWithLifecycle()
 
+    LaunchedEffect(Unit) {
+        viewModel.getSortMode(listId)
+    }
+    
     AddItemScreen(
         listName = listName,
         state = state,

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/products_screen/ui/AddItemRoute.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/products_screen/ui/AddItemRoute.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.dimasla4ee.shoppinglist.feature.products_screen.presentation.model.ProductsViewModel
-import io.dimasla4ee.shoppinglist.feature.shopping_lists.presentation.ShoppingListItem
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
@@ -21,7 +20,7 @@ fun AddItemRoute(
     LaunchedEffect(Unit) {
         viewModel.getSortMode(listId)
     }
-    
+
     AddItemScreen(
         listName = listName,
         state = state,

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/products_screen/ui/AddItemScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/products_screen/ui/AddItemScreen.kt
@@ -49,7 +49,7 @@ import io.dimasla4ee.shoppinglist.core.presentation.components.AppTopBar
 import io.dimasla4ee.shoppinglist.core.presentation.components.TopBarIcon
 import io.dimasla4ee.shoppinglist.feature.products_screen.presentation.model.AddProductUiState
 import io.dimasla4ee.shoppinglist.feature.products_screen.presentation.model.ProductsIntent
-import io.dimasla4ee.shoppinglist.feature.products_screen.presentation.model.SortMode
+import io.dimasla4ee.shoppinglist.feature.products_screen.domain.SortMode
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import sh.calvin.reorderable.rememberReorderableLazyListState

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/products_screen/ui/AddItemScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/products_screen/ui/AddItemScreen.kt
@@ -349,6 +349,7 @@ fun SortModeIndicator(
 private fun AddItemScreenPreview() {
     ShoppingListTheme {
         AddItemRoute(
+            listId = 0,
             listName = "Bobs",
             onBackClick = {},
             onMenuClick = {}

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/products_screen/ui/AddItemScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/products_screen/ui/AddItemScreen.kt
@@ -47,9 +47,9 @@ import androidx.compose.ui.unit.dp
 import io.dimasla4ee.shoppinglist.app.ui.theme.ShoppingListTheme
 import io.dimasla4ee.shoppinglist.core.presentation.components.AppTopBar
 import io.dimasla4ee.shoppinglist.core.presentation.components.TopBarIcon
+import io.dimasla4ee.shoppinglist.feature.products_screen.domain.SortMode
 import io.dimasla4ee.shoppinglist.feature.products_screen.presentation.model.AddProductUiState
 import io.dimasla4ee.shoppinglist.feature.products_screen.presentation.model.ProductsIntent
-import io.dimasla4ee.shoppinglist.feature.products_screen.domain.SortMode
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import sh.calvin.reorderable.rememberReorderableLazyListState
@@ -164,7 +164,7 @@ fun AddItemScreen(
                                 item = item,
                                 state = reorderableLazyListState,
                                 hapticFeedback = hapticFeedback,
-                                onCheckedChange = { onIntent(ProductsIntent.ToggleItemChecked(item.id)) },
+                                onCheckedChange = { onIntent(ProductsIntent.ToggleItemChecked(item)) },
                                 showDragHandle = isCustomSort
                             )
                         }

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/shopping_lists/presentation/ShoppingListsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/shopping_lists/presentation/ShoppingListsViewModel.kt
@@ -1,5 +1,6 @@
 package io.dimasla4ee.shoppinglist.feature.shopping_lists.presentation
 
+import io.dimasla4ee.shoppinglist.core.domain.interactor.sorting.RemoveSortModeUseCase
 import io.dimasla4ee.shoppinglist.core.mvi.MviViewModel
 import io.dimasla4ee.shoppinglist.feature.shopping_lists.domain.ShoppingListsInteractor
 import io.dimasla4ee.shoppinglist.feature.shopping_lists.presentation.state.ShoppingListDialog
@@ -9,73 +10,67 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 class ShoppingListsViewModel(
-    private val interactor: ShoppingListsInteractor
-) : MviViewModel<
-        ShoppingListsIntent,
-        ShoppingListsState,
-        ShoppingListsEffect
-        >(
-    ShoppingListsState()
+    private val interactor: ShoppingListsInteractor,
+    private val removeSortModeUseCase: RemoveSortModeUseCase
+) : MviViewModel<ShoppingListsIntent, ShoppingListsState, ShoppingListsEffect>(
+    initialState = ShoppingListsState()
 ) {
     private var observeJob: Job? = null
 
     override fun reduce(
         intent: ShoppingListsIntent,
         current: ShoppingListsState
-    ): ShoppingListsState {
+    ): ShoppingListsState = when (intent) {
 
-        return when (intent) {
-
-            ShoppingListsIntent.FabClick -> {
-                reduceFabClick(current)
-            }
-
-            is ShoppingListsIntent.NameChanged -> {
-                reduceNameChanged(intent, current)
-            }
-
-            ShoppingListsIntent.DialogDismiss -> {
-                reduceDialogDismiss(current)
-            }
-
-            ShoppingListsIntent.DeleteAllClick -> {
-                reduceDeleteAllClick(current)
-            }
-
-            ShoppingListsIntent.SearchClick -> {
-                reduceSearchClick(current)
-            }
-
-            ShoppingListsIntent.SearchDismiss -> {
-                reduceSearchDismiss(current)
-            }
-
-            is ShoppingListsIntent.SearchQueryChanged -> {
-                reduceSearchQueryChanged(intent, current)
-            }
-
-            is ShoppingListsIntent.RenameValueChanged -> {
-                reduceRenameValueChanged(intent, current)
-            }
-
-            is ShoppingListsIntent.EditClicked -> {
-                reduceEditClicked(intent, current)
-            }
-
-            is ShoppingListsIntent.DeleteClicked -> {
-                reduceDeleteClicked(intent, current)
-            }
-
-            is ShoppingListsIntent.ChangeIconClicked -> {
-                reduceChangeIconClicked(intent, current)
-            }
-
-            ShoppingListsIntent.SheetDismiss -> {
-                reduceSheetDismiss(current)
-            }
-
-            else -> current
+        ShoppingListsIntent.FabClick -> {
+            reduceFabClick(current)
         }
+
+        is ShoppingListsIntent.NameChanged -> {
+            reduceNameChanged(intent, current)
+        }
+
+        ShoppingListsIntent.DialogDismiss -> {
+            reduceDialogDismiss(current)
+        }
+
+        ShoppingListsIntent.DeleteAllClick -> {
+            reduceDeleteAllClick(current)
+        }
+
+        ShoppingListsIntent.SearchClick -> {
+            reduceSearchClick(current)
+        }
+
+        ShoppingListsIntent.SearchDismiss -> {
+            reduceSearchDismiss(current)
+        }
+
+        is ShoppingListsIntent.SearchQueryChanged -> {
+            reduceSearchQueryChanged(intent, current)
+        }
+
+        is ShoppingListsIntent.RenameValueChanged -> {
+            reduceRenameValueChanged(intent, current)
+        }
+
+        is ShoppingListsIntent.EditClicked -> {
+            reduceEditClicked(intent, current)
+        }
+
+        is ShoppingListsIntent.DeleteClicked -> {
+            reduceDeleteClicked(intent, current)
+        }
+
+        is ShoppingListsIntent.ChangeIconClicked -> {
+            reduceChangeIconClicked(intent, current)
+        }
+
+        ShoppingListsIntent.SheetDismiss -> {
+            reduceSheetDismiss(current)
+        }
+
+        else -> current
     }
 
     private fun reduceFabClick(
@@ -341,6 +336,7 @@ class ShoppingListsViewModel(
             ?: return
 
         interactor.deleteShoppingList(target)
+        removeSortModeUseCase(dialog.id)
 
         dispatch(
             ShoppingListsIntent.DialogDismiss

--- a/composeApp/src/jvmMain/kotlin/io/dimasla4ee/shoppinglist/app/data/repository/SettingsRepositoryJVM.kt
+++ b/composeApp/src/jvmMain/kotlin/io/dimasla4ee/shoppinglist/app/data/repository/SettingsRepositoryJVM.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import io.dimasla4ee.shoppinglist.app.ui.theme.ThemeMode
 import io.dimasla4ee.shoppinglist.core.domain.repository.SettingsRepository
+import io.dimasla4ee.shoppinglist.feature.products_screen.domain.SortMode
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -15,6 +16,7 @@ class SettingsRepositoryJVM(
 
     private companion object {
         val THEME_KEY = stringPreferencesKey("theme_mode")
+        private fun sortModeKey(listId: Long) = stringPreferencesKey("sort_mode_$listId")
     }
 
     override val themeMode: Flow<ThemeMode> = dataStore.data.map { preferences ->
@@ -25,6 +27,30 @@ class SettingsRepositoryJVM(
     override suspend fun setThemeMode(mode: ThemeMode) {
         dataStore.edit { preferences ->
             preferences[THEME_KEY] = mode.name
+        }
+    }
+
+    override fun observeSortMode(listId: Long): Flow<SortMode> = dataStore.data
+        .map { preferences ->
+            val key = sortModeKey(listId)
+            val value = preferences[key] ?: SortMode.CUSTOM.name
+            SortMode.valueOf(value)
+        }
+
+    override suspend fun setSortMode(listId: Long, mode: SortMode) {
+        dataStore.updateData { preferences ->
+            preferences.toMutablePreferences().apply {
+                val key = sortModeKey(listId)
+                this[key] = mode.name
+            }
+        }
+    }
+
+    override suspend fun removeSortMode(listId: Long) {
+        dataStore.updateData { preferences ->
+            preferences.toMutablePreferences().apply {
+                remove(sortModeKey(listId))
+            }
         }
     }
 }


### PR DESCRIPTION
## Персистентность режима сортировки и улучшение логики товаров

Resolves #129

### Что сделано

#### Перенос SortMode в доменный слой
- `SortMode` перемещён из presentation слоя в domain
- Созданы use case'ы для работы с режимом сортировки:
  - `GetSortModeUseCase` — получение сохранённого режима
  - `SetSortModeUseCase` — сохранение режима
  - `RemoveSortModeUseCase` — удаление режима
- Обновлены `SettingsRepository` и `SettingsDataSource` для поддержки **перестановок (per‑list) через DataStore**
- Зарегистрированы новые use case'ы в `DomainModule`

#### Персистентность режима сортировки на экране товаров
- В `ProductsViewModel` добавлены инжекты `GetSortModeUseCase` и `SetSortModeUseCase`
- В маршрут `AddItemRoute` и экран `AddItemScreen` добавлен параметр `listId` для загрузки настроек конкретного списка
- Добавлен `LaunchedEffect` при входе на экран товаров для загрузки сохранённого режима сортировки
- Переупорядочивание товаров теперь разрешено **только при режиме `CUSTOM`**
- Обновлён `PresentationModule`: инжект `ProductsViewModel` переведён на `viewModelOf`
- Обновлён `EntryProvider`: `listId` передаётся из навигационного маршрута

#### Удаление режима сортировки
- Обновлён `ShoppingListsViewModel`: теперь при удалении списка также вызывается `RemoveSortModeUseCase` для очистки сохранённых настроек сортировки

#### Рефакторинг DI
- `PresentationModule.kt` обновлён: инжект `ShoppingListsViewModel` переведён на `viewModelOf` для единообразия с другими ViewModel

#### Рефакторинг логики переключения товара
- `ProductsIntent.ToggleItemChecked` изменён: теперь принимает `Product` вместо `Long id`
- Упрощена логика переключения в `ProductsViewModel` — обновление состояния происходит напрямую через объект продукта
- Удалены неиспользуемые импорты, выполнено мелкое форматирование в `AddItemRoute` и `AddItemScreen`

### Затронутые файлы
- `domain/model/SortMode.kt` — перемещён из presentation
- `domain/interactor/sort_mode/*.kt` — три новых use case'а
- `domain/repository/SettingsRepository.kt` — обновлён интерфейс
- `data/datasource/SettingsDataSource.kt` — поддержка per‑list DataStore
- `data/repository/SettingsRepositoryImpl.kt` — реализация
- `app/di/DomainModule.kt` — регистрация use case'ов
- `app/di/PresentationModule.kt` — обновлён инжект ProductsViewModel
- `app/navigation/EntryProvider.kt` — передача listId
- `feature/products_screen/presentation/ProductsViewModel.kt` — логика персистентности
- `feature/products_screen/ui/add_item/AddItemRoute.kt` — параметр listId
- `feature/products_screen/ui/add_item/AddItemScreen.kt` — интеграция с сортировкой
- `feature/shopping_lists/presentation/ShoppingListsViewModel.kt`