### PR TITLE
feature/splash-screen

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,0 +1,56 @@
+name: Android Release
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Restore keystore
+        run: echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode > shoppinglist-release.jks
+
+      - name: Create keystore.properties
+        run: |
+          cat > keystore.properties <<EOF
+          STORE_FILE=shoppinglist-release.jks
+          STORE_PASSWORD=${{ secrets.STORE_PASSWORD }}
+          KEY_ALIAS=${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD=${{ secrets.KEY_PASSWORD }}
+          EOF
+
+      - name: Build release APK
+        run: ./gradlew :composeApp:assembleRelease
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: composeApp-release
+          path: composeApp/build/outputs/apk/release/*.apk
+
+      - name: Build release AAB
+        run: ./gradlew :composeApp:bundleRelease
+
+      - name: Upload AAB artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: shoppinglist-release-aab-${{ github.sha }}
+          path: composeApp/build/outputs/bundle/release/*.aab

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ captures
 !*.xcworkspace/contents.xcworkspacedata
 **/xcshareddata/WorkspaceSettings.xcsettings
 node_modules/
+# Release signing
+*.jks
+*.keystore
+keystore.properties

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -2,6 +2,9 @@ import dev.detekt.gradle.Detekt
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
+import java.util.Properties
+import java.io.FileInputStream
+
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidApplication)
@@ -58,7 +61,7 @@ kotlin {
 
             implementation(libs.koin.android)
 
-            implementation("me.gosimple:nbvcxz:1.5.1")
+            implementation(libs.nbvcxz)
         }
         commonMain.dependencies {
             implementation(libs.compose.runtime)
@@ -103,9 +106,9 @@ kotlin {
             implementation(compose.desktop.currentOs)
             implementation(libs.ktor.client.okhttp)
 
-            implementation("me.gosimple:nbvcxz:1.5.1")
+            implementation(libs.nbvcxz)
 
-            implementation("org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.10.2")
+            implementation(libs.kotlinx.coroutines.swing)
         }
     }
 }
@@ -121,16 +124,48 @@ android {
         versionCode = 1
         versionName = "1.0"
     }
+
+    val keystoreProperties = Properties()
+    val keystorePropertiesFile = rootProject.file("keystore.properties")
+
+    if (keystorePropertiesFile.exists()) { keystoreProperties.load(FileInputStream(keystorePropertiesFile)) }
+
+    signingConfigs {
+        create("release") {
+            if (keystorePropertiesFile.exists()) {
+                storeFile = rootProject.file(keystoreProperties["STORE_FILE"] as String)
+                storePassword = keystoreProperties["STORE_PASSWORD"] as String
+                keyAlias = keystoreProperties["KEY_ALIAS"] as String
+                keyPassword = keystoreProperties["KEY_PASSWORD"] as String
+            }
+        }
+    }
+
+    buildTypes {
+        getByName("debug") {
+            applicationIdSuffix = ".debug"
+            versionNameSuffix = "-debug"
+        }
+
+        getByName("release") {
+            isMinifyEnabled = true
+            isShrinkResources = true
+            isDebuggable = false
+
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+            if (keystorePropertiesFile.exists()) { signingConfig = signingConfigs.getByName("release") }
+        }
+    }
+
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
-    buildTypes {
-        getByName("release") {
-            isMinifyEnabled = false
-        }
-    }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11

--- a/composeApp/proguard-rules.pro
+++ b/composeApp/proguard-rules.pro
@@ -1,0 +1,68 @@
+########################################
+# Kotlin Serialization
+########################################
+
+-keep class kotlinx.serialization.** { *; }
+
+-keepclassmembers class ** {
+    @kotlinx.serialization.Serializable *;
+}
+
+-keepclassmembers class * {
+    *** Companion;
+}
+
+-keepclassmembers class **$$serializer {
+    *;
+}
+
+########################################
+# Ktorfit
+########################################
+
+-keep class de.jensklingenberg.ktorfit.** { *; }
+
+########################################
+# Ktor
+########################################
+
+-keep class io.ktor.** { *; }
+
+########################################
+# Koin
+########################################
+
+-keep class org.koin.** { *; }
+
+########################################
+# Room
+########################################
+
+-keep class androidx.room.** { *; }
+
+########################################
+# Compose
+########################################
+
+-keep class androidx.compose.** { *; }
+
+########################################
+# Coroutines
+########################################
+
+-keep class kotlinx.coroutines.** { *; }
+
+########################################
+# Enums
+########################################
+
+-keepclassmembers enum * {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}
+
+########################################
+# Management
+########################################
+
+-dontwarn java.lang.management.*

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/App.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import io.dimasla4ee.shoppinglist.app.navigation.NavigationRoot
+import io.dimasla4ee.shoppinglist.app.startup.session.presentation.SessionViewModel
 import io.dimasla4ee.shoppinglist.app.ui.theme.ShoppingListTheme
 import io.dimasla4ee.shoppinglist.app.ui.theme.ThemeMode
 import io.dimasla4ee.shoppinglist.core.presentation.settings.SettingsViewModel
@@ -16,6 +17,8 @@ import org.koin.compose.viewmodel.koinViewModel
 @Composable
 @PreviewLightDark
 fun App() {
+
+    val sessionViewModel: SessionViewModel = koinViewModel()
 
     val viewModel: SettingsViewModel = koinViewModel()
 
@@ -35,6 +38,7 @@ fun App() {
     ) {
 
         NavigationRoot(
+            sessionViewModel = sessionViewModel,
             onThemeToggle = viewModel::toggleTheme,
             modifier = Modifier.fillMaxSize()
         )

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/di/DataModule.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/di/DataModule.kt
@@ -3,6 +3,8 @@ package io.dimasla4ee.shoppinglist.app.di
 import androidx.room.RoomDatabase
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import de.jensklingenberg.ktorfit.Ktorfit
+import io.dimasla4ee.shoppinglist.app.startup.session.data.AppLaunchRepositoryImpl
+import io.dimasla4ee.shoppinglist.app.startup.session.domain.AppLaunchRepository
 import io.dimasla4ee.shoppinglist.core.data.network.api.AuthApi
 import io.dimasla4ee.shoppinglist.core.data.network.client.KtorfitNetworkClient
 import io.dimasla4ee.shoppinglist.core.data.network.client.NetworkClient
@@ -99,6 +101,10 @@ val dataModule = module {
         ProductRepositoryImpl(
             dao = get()
         )
+    }
+
+    single<AppLaunchRepository> {
+        AppLaunchRepositoryImpl(get())
     }
 
 

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/di/PresentationModule.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/di/PresentationModule.kt
@@ -1,6 +1,8 @@
 package io.dimasla4ee.shoppinglist.app.di
 
 import io.dimasla4ee.shoppinglist.app.navigation.NavigationViewModel
+import io.dimasla4ee.shoppinglist.app.startup.session.presentation.SessionViewModel
+import io.dimasla4ee.shoppinglist.app.startup.session.splash.presentation.SplashViewModel
 import io.dimasla4ee.shoppinglist.core.presentation.settings.SettingsViewModel
 import io.dimasla4ee.shoppinglist.feature.authorization.presentation.recover_password.RecoverPasswordViewModel
 import io.dimasla4ee.shoppinglist.feature.authorization.presentation.register.RegisterViewModel
@@ -33,6 +35,8 @@ val presentationModule = module {
     viewModelOf(::SignInViewModel)
     viewModelOf(::RegisterViewModel)
     viewModelOf(::RecoverPasswordViewModel)
+    viewModelOf(::SessionViewModel)
+    viewModelOf(::SplashViewModel)
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/navigation/EntryProvider.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/navigation/EntryProvider.kt
@@ -30,11 +30,13 @@ import io.dimasla4ee.shoppinglist.feature.shopping_lists.presentation.ShoppingLi
 import io.dimasla4ee.shoppinglist.feature.shopping_lists.presentation.ShoppingListsViewModel
 import io.dimasla4ee.shoppinglist.feature.shopping_lists.ui.screen.ShoppingListsScreen
 import io.dimasla4ee.shoppinglist.feature.welcome_screen.ui.WelcomeScreen
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 
+const val SPLASH_SCREEN_DELAY = 1000L
 fun entryProvider(
     topLevelBackStack: TopLevelBackStack<NavKey>,
     sessionViewModel: SessionViewModel,
@@ -47,6 +49,7 @@ fun entryProvider(
         SplashScreen(modifier = Modifier.fillMaxSize())
 
         LaunchedEffect(Unit) {
+            delay(SPLASH_SCREEN_DELAY)
             splashViewModel.dispatch(SplashIntent.Initialize)
 
             splashViewModel.effects.collect { effect ->
@@ -80,7 +83,6 @@ fun entryProvider(
         val isAuthorized = sessionState.refreshToken != null
 
         LaunchedEffect(Unit) {
-
             viewModel.dispatch(
                 ShoppingListsIntent.ObserveLists
             )
@@ -115,7 +117,6 @@ fun entryProvider(
     }
 
     entry<Route.ProductsList> { route ->
-
         AddItemRoute(
             listId = route.listId,
             listName = route.listName,

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/navigation/EntryProvider.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/navigation/EntryProvider.kt
@@ -8,16 +8,9 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
-import io.dimasla4ee.shoppinglist.app.navigation.Route.Authorization
-import io.dimasla4ee.shoppinglist.app.navigation.Route.PasswordRecovery
-import io.dimasla4ee.shoppinglist.app.navigation.Route.ProductsList
-import io.dimasla4ee.shoppinglist.app.navigation.Route.Registration
-import io.dimasla4ee.shoppinglist.app.navigation.Route.ShoppingLists
-import io.dimasla4ee.shoppinglist.app.navigation.Route.Welcome
 import io.dimasla4ee.shoppinglist.app.startup.session.domain.AppLaunchRepository
 import io.dimasla4ee.shoppinglist.app.startup.session.presentation.SessionIntent
 import io.dimasla4ee.shoppinglist.app.startup.session.presentation.SessionViewModel
-import io.dimasla4ee.shoppinglist.app.startup.session.splash.domain.SplashDestination
 import io.dimasla4ee.shoppinglist.app.startup.session.splash.presentation.SplashEffect
 import io.dimasla4ee.shoppinglist.app.startup.session.splash.presentation.SplashIntent
 import io.dimasla4ee.shoppinglist.app.startup.session.splash.presentation.SplashViewModel
@@ -50,25 +43,18 @@ fun entryProvider(
 
     entry<Route.Splash> {
         val splashViewModel = koinViewModel<SplashViewModel>()
-        val state by splashViewModel.state.collectAsState()
-        SplashScreen(
-            modifier = Modifier.fillMaxSize()
-        )
+
+        SplashScreen(modifier = Modifier.fillMaxSize())
+
         LaunchedEffect(Unit) {
             splashViewModel.dispatch(SplashIntent.Initialize)
-        }
-        LaunchedEffect(state.destination) {
-            when (state.destination) {
 
-                SplashDestination.Welcome -> {
-                    topLevelBackStack.replaceStack(Route.Welcome)
+            splashViewModel.effects.collect { effect ->
+                val destination = when (effect) {
+                    SplashEffect.NavigateToShoppingLists -> Route.ShoppingLists
+                    SplashEffect.NavigateToWelcome -> Route.Welcome
                 }
-
-                SplashDestination.ShoppingLists -> {
-                    topLevelBackStack.replaceStack(Route.ShoppingLists)
-                }
-
-                null -> Unit
+                topLevelBackStack.replaceStack(destination)
             }
         }
     }
@@ -79,16 +65,14 @@ fun entryProvider(
 
         WelcomeScreen(
             onGoToShopping = {
-                scope.launch {
-                    appLaunchRepository.setLaunched()
-                }
+                scope.launch { appLaunchRepository.setLaunched() }
                 topLevelBackStack.replaceStack(Route.ShoppingLists)
             },
             modifier = Modifier.fillMaxSize()
         )
     }
 
-    entry<ShoppingLists> {
+    entry<Route.ShoppingLists> {
         val viewModel: ShoppingListsViewModel = koinViewModel()
         val sessionState by sessionViewModel.state.collectAsState()
 
@@ -107,7 +91,7 @@ fun entryProvider(
                 when (effect) {
                     is ShoppingListsEffect.NavigateToProducts -> {
                         topLevelBackStack.add(
-                            ProductsList(
+                            Route.ProductsList(
                                 listId = effect.listId,
                                 listName = effect.listName
                             )
@@ -115,7 +99,7 @@ fun entryProvider(
                     }
 
                     is ShoppingListsEffect.NavigateToAuthorization -> {
-                        topLevelBackStack.add(Authorization)
+                        topLevelBackStack.add(Route.Authorization)
                     }
                 }
             }
@@ -130,7 +114,7 @@ fun entryProvider(
         )
     }
 
-    entry<ProductsList> { route ->
+    entry<Route.ProductsList> { route ->
 
         AddItemRoute(
             listId = route.listId,
@@ -169,7 +153,7 @@ fun entryProvider(
         )
     }
 
-    entry<Registration> {
+    entry<Route.Registration> {
         val viewModel = koinViewModel<RegisterViewModel>()
         val state by viewModel.state.collectAsState()
 
@@ -195,7 +179,7 @@ fun entryProvider(
         )
     }
 
-    entry<PasswordRecovery> {
+    entry<Route.PasswordRecovery> {
         val viewModel = koinViewModel<RecoverPasswordViewModel>()
         val state by viewModel.state.collectAsState()
 

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/navigation/EntryProvider.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/navigation/EntryProvider.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
@@ -13,6 +14,14 @@ import io.dimasla4ee.shoppinglist.app.navigation.Route.ProductsList
 import io.dimasla4ee.shoppinglist.app.navigation.Route.Registration
 import io.dimasla4ee.shoppinglist.app.navigation.Route.ShoppingLists
 import io.dimasla4ee.shoppinglist.app.navigation.Route.Welcome
+import io.dimasla4ee.shoppinglist.app.startup.session.domain.AppLaunchRepository
+import io.dimasla4ee.shoppinglist.app.startup.session.presentation.SessionIntent
+import io.dimasla4ee.shoppinglist.app.startup.session.presentation.SessionViewModel
+import io.dimasla4ee.shoppinglist.app.startup.session.splash.domain.SplashDestination
+import io.dimasla4ee.shoppinglist.app.startup.session.splash.presentation.SplashEffect
+import io.dimasla4ee.shoppinglist.app.startup.session.splash.presentation.SplashIntent
+import io.dimasla4ee.shoppinglist.app.startup.session.splash.presentation.SplashViewModel
+import io.dimasla4ee.shoppinglist.app.startup.session.splash.ui.SplashScreen
 import io.dimasla4ee.shoppinglist.feature.authorization.presentation.recover_password.RecoverPasswordEffect
 import io.dimasla4ee.shoppinglist.feature.authorization.presentation.recover_password.RecoverPasswordViewModel
 import io.dimasla4ee.shoppinglist.feature.authorization.presentation.register.RegisterEffect
@@ -29,23 +38,62 @@ import io.dimasla4ee.shoppinglist.feature.shopping_lists.presentation.ShoppingLi
 import io.dimasla4ee.shoppinglist.feature.shopping_lists.ui.screen.ShoppingListsScreen
 import io.dimasla4ee.shoppinglist.feature.welcome_screen.ui.WelcomeScreen
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 
 fun entryProvider(
     topLevelBackStack: TopLevelBackStack<NavKey>,
+    sessionViewModel: SessionViewModel,
     onThemeToggle: () -> Unit,
 ) = entryProvider<NavKey> {
-    entry<Welcome> {
+
+    entry<Route.Splash> {
+        val splashViewModel = koinViewModel<SplashViewModel>()
+        val state by splashViewModel.state.collectAsState()
+        SplashScreen(
+            modifier = Modifier.fillMaxSize()
+        )
+        LaunchedEffect(Unit) {
+            splashViewModel.dispatch(SplashIntent.Initialize)
+        }
+        LaunchedEffect(state.destination) {
+            when (state.destination) {
+
+                SplashDestination.Welcome -> {
+                    topLevelBackStack.replaceStack(Route.Welcome)
+                }
+
+                SplashDestination.ShoppingLists -> {
+                    topLevelBackStack.replaceStack(Route.ShoppingLists)
+                }
+
+                null -> Unit
+            }
+        }
+    }
+
+    entry<Route.Welcome> {
+        val appLaunchRepository = koinInject<AppLaunchRepository>()
+        val scope = rememberCoroutineScope()
+
         WelcomeScreen(
-            onGoToShopping = { topLevelBackStack.add(Authorization) },
+            onGoToShopping = {
+                scope.launch {
+                    appLaunchRepository.setLaunched()
+                }
+                topLevelBackStack.replaceStack(Route.ShoppingLists)
+            },
             modifier = Modifier.fillMaxSize()
         )
     }
 
     entry<ShoppingLists> {
         val viewModel: ShoppingListsViewModel = koinViewModel()
+        val sessionState by sessionViewModel.state.collectAsState()
 
         val state by viewModel.state.collectAsState()
+        val isAuthorized = sessionState.refreshToken != null
 
         LaunchedEffect(Unit) {
 
@@ -67,7 +115,7 @@ fun entryProvider(
                     }
 
                     is ShoppingListsEffect.NavigateToAuthorization -> {
-                        topLevelBackStack.replaceStack(Authorization)
+                        topLevelBackStack.add(Authorization)
                     }
                 }
             }
@@ -75,6 +123,7 @@ fun entryProvider(
 
         ShoppingListsScreen(
             state = state,
+            isAuthorized = isAuthorized,
             onIntent = viewModel::dispatch,
             onThemeToggle = onThemeToggle,
             modifier = Modifier.fillMaxSize()
@@ -90,7 +139,7 @@ fun entryProvider(
         )
     }
 
-    entry<Authorization> {
+    entry<Route.Authorization> {
         val viewModel = koinViewModel<SignInViewModel>()
         val state by viewModel.state.collectAsState()
 
@@ -98,15 +147,16 @@ fun entryProvider(
             viewModel.effects.collect { effect ->
                 when (effect) {
                     SignInEffect.NavigateToMain -> {
-                        topLevelBackStack.replaceStack(ShoppingLists)
+                        sessionViewModel.dispatch(SessionIntent.LoadSession)
+                        topLevelBackStack.removeLast()
                     }
 
                     SignInEffect.NavigateToRecoverPassword -> {
-                        topLevelBackStack.add(PasswordRecovery)
+                        topLevelBackStack.add(Route.PasswordRecovery)
                     }
 
                     SignInEffect.NavigateToRegister -> {
-                        topLevelBackStack.add(Registration)
+                        topLevelBackStack.add(Route.Registration)
                     }
                 }
             }
@@ -127,7 +177,8 @@ fun entryProvider(
             viewModel.effects.collect { effect ->
                 when (effect) {
                     RegisterEffect.NavigateToMain -> {
-                        topLevelBackStack.replaceStack(ShoppingLists)
+                        sessionViewModel.dispatch(SessionIntent.LoadSession)
+                        topLevelBackStack.removeLast()
                     }
 
                     RegisterEffect.NavigateToSignIn -> {

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/navigation/NavigationRoot.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/navigation/NavigationRoot.kt
@@ -9,11 +9,13 @@ import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
+import io.dimasla4ee.shoppinglist.app.startup.session.presentation.SessionViewModel
 import org.koin.compose.viewmodel.koinViewModel
 import kotlin.collections.listOf
 
 @Composable
 fun NavigationRoot(
+    sessionViewModel: SessionViewModel,
     onThemeToggle: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: NavigationViewModel = koinViewModel()
@@ -25,7 +27,8 @@ fun NavigationRoot(
     ) {
         entryProvider(
             topLevelBackStack = topLevelBackStack,
-            onThemeToggle = onThemeToggle
+            onThemeToggle = onThemeToggle,
+            sessionViewModel = sessionViewModel
         )
     }
 

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/navigation/NavigationViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/navigation/NavigationViewModel.kt
@@ -5,6 +5,6 @@ import androidx.navigation3.runtime.NavKey
 
 class NavigationViewModel : ViewModel() {
     val backStack = TopLevelBackStack<NavKey>(
-        startKey = Route.Welcome
+        startKey = Route.Splash
     )
 }

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/navigation/Route.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/navigation/Route.kt
@@ -7,8 +7,10 @@ import kotlinx.serialization.Serializable
 sealed interface Route : NavKey {
 
     @Serializable
-    data object Welcome : Route
+    data object Splash : Route
 
+    @Serializable
+    data object Welcome : Route
     @Serializable
     data object ShoppingLists : Route
 

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/data/AppLaunchRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/data/AppLaunchRepositoryImpl.kt
@@ -1,0 +1,28 @@
+package io.dimasla4ee.shoppinglist.app.startup.session.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import io.dimasla4ee.shoppinglist.app.startup.session.domain.AppLaunchRepository
+import kotlinx.coroutines.flow.first
+
+class AppLaunchRepositoryImpl(
+    private val dataStore: DataStore<Preferences>
+) : AppLaunchRepository {
+
+    private companion object {
+        val FIRST_LAUNCH_KEY = booleanPreferencesKey("first_launch")
+    }
+
+    override suspend fun isFirstLaunch(): Boolean {
+        return dataStore.data.first()[FIRST_LAUNCH_KEY] != false
+    }
+
+    override suspend fun setLaunched() {
+
+        dataStore.edit { preferences ->
+            preferences[FIRST_LAUNCH_KEY] = false
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/domain/AppLaunchRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/domain/AppLaunchRepository.kt
@@ -1,0 +1,6 @@
+package io.dimasla4ee.shoppinglist.app.startup.session.domain
+
+interface AppLaunchRepository {
+    suspend fun isFirstLaunch(): Boolean
+    suspend fun setLaunched()
+}

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/presentation/SessionEffect.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/presentation/SessionEffect.kt
@@ -1,0 +1,5 @@
+package io.dimasla4ee.shoppinglist.app.startup.session.presentation
+
+import io.dimasla4ee.shoppinglist.core.mvi.MviEffect
+
+sealed interface SessionEffect : MviEffect

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/presentation/SessionIntent.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/presentation/SessionIntent.kt
@@ -1,0 +1,9 @@
+package io.dimasla4ee.shoppinglist.app.startup.session.presentation
+
+import io.dimasla4ee.shoppinglist.core.mvi.MviIntent
+
+sealed interface SessionIntent : MviIntent {
+    data object LoadSession : SessionIntent
+    data object Logout : SessionIntent
+    data object RefreshSession : SessionIntent
+}

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/presentation/SessionState.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/presentation/SessionState.kt
@@ -1,0 +1,11 @@
+package io.dimasla4ee.shoppinglist.app.startup.session.presentation
+
+import io.dimasla4ee.shoppinglist.core.mvi.MviState
+
+data class SessionState(
+    val isLoading: Boolean = false,
+    val isAuthorized: Boolean = false,
+
+    val accessToken: String? = null,
+    val refreshToken: String? = null
+) : MviState

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/presentation/SessionViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/presentation/SessionViewModel.kt
@@ -1,0 +1,61 @@
+package io.dimasla4ee.shoppinglist.app.startup.session.presentation
+
+import io.dimasla4ee.shoppinglist.core.domain.repository.AuthRepository
+import io.dimasla4ee.shoppinglist.core.mvi.MviViewModel
+
+class SessionViewModel(
+    private val authRepository: AuthRepository
+) : MviViewModel<SessionIntent, SessionState, SessionEffect>(
+    initialState = SessionState()
+) {
+
+    override fun reduce(
+        intent: SessionIntent,
+        current: SessionState
+    ): SessionState = when (intent) {
+        SessionIntent.LoadSession,
+        SessionIntent.RefreshSession -> {
+            current.copy(isLoading = true)
+        }
+        SessionIntent.Logout -> {
+            current.copy(isLoading = true)
+        }
+    }
+
+    override suspend fun handleIntent(intent: SessionIntent) {
+        when (intent) {
+
+            SessionIntent.LoadSession -> {
+                loadSession()
+            }
+
+            SessionIntent.RefreshSession -> {
+                loadSession()
+            }
+
+            SessionIntent.Logout -> {
+                logout()
+            }
+        }
+    }
+
+    private suspend fun loadSession() {
+        val accessToken = authRepository.getAccessToken()
+        val refreshToken = authRepository.getRefreshToken()
+        updateState {
+            it.copy(
+                isLoading = false,
+                isAuthorized = refreshToken != null,
+                accessToken = accessToken,
+                refreshToken = refreshToken
+            )
+        }
+    }
+
+    private suspend fun logout() {
+        authRepository.clearTokens()
+        updateState {
+            SessionState()
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/presentation/SessionViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/presentation/SessionViewModel.kt
@@ -8,7 +8,7 @@ class SessionViewModel(
 ) : MviViewModel<SessionIntent, SessionState, SessionEffect>(
     initialState = SessionState()
 ) {
-
+    
     override fun reduce(
         intent: SessionIntent,
         current: SessionState

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/presentation/SessionViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/presentation/SessionViewModel.kt
@@ -14,28 +14,16 @@ class SessionViewModel(
         current: SessionState
     ): SessionState = when (intent) {
         SessionIntent.LoadSession,
-        SessionIntent.RefreshSession -> {
-            current.copy(isLoading = true)
-        }
-        SessionIntent.Logout -> {
-            current.copy(isLoading = true)
-        }
+        SessionIntent.RefreshSession -> current.copy(isLoading = true)
+
+        SessionIntent.Logout -> current.copy(isLoading = true)
     }
 
     override suspend fun handleIntent(intent: SessionIntent) {
         when (intent) {
-
-            SessionIntent.LoadSession -> {
-                loadSession()
-            }
-
-            SessionIntent.RefreshSession -> {
-                loadSession()
-            }
-
-            SessionIntent.Logout -> {
-                logout()
-            }
+            SessionIntent.LoadSession -> loadSession()
+            SessionIntent.RefreshSession -> loadSession()
+            SessionIntent.Logout -> logout()
         }
     }
 
@@ -54,8 +42,6 @@ class SessionViewModel(
 
     private suspend fun logout() {
         authRepository.clearTokens()
-        updateState {
-            SessionState()
-        }
+        updateState { SessionState() }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/splash/domain/SplashDestination.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/splash/domain/SplashDestination.kt
@@ -1,0 +1,7 @@
+package io.dimasla4ee.shoppinglist.app.startup.session.splash.domain
+
+sealed interface SplashDestination {
+
+    data object Welcome : SplashDestination
+    data object ShoppingLists : SplashDestination
+}

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/splash/presentation/SplashEffect.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/splash/presentation/SplashEffect.kt
@@ -1,0 +1,9 @@
+package io.dimasla4ee.shoppinglist.app.startup.session.splash.presentation
+
+import io.dimasla4ee.shoppinglist.core.mvi.MviEffect
+
+sealed interface SplashEffect : MviEffect {
+
+    data object NavigateToWelcome : SplashEffect
+    data object NavigateToShoppingLists : SplashEffect
+}

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/splash/presentation/SplashIntent.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/splash/presentation/SplashIntent.kt
@@ -1,0 +1,8 @@
+package io.dimasla4ee.shoppinglist.app.startup.session.splash.presentation
+
+import io.dimasla4ee.shoppinglist.core.mvi.MviIntent
+
+sealed interface SplashIntent : MviIntent {
+
+    data object Initialize : SplashIntent
+}

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/splash/presentation/SplashState.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/splash/presentation/SplashState.kt
@@ -1,0 +1,9 @@
+package io.dimasla4ee.shoppinglist.app.startup.session.splash.presentation
+
+import io.dimasla4ee.shoppinglist.app.startup.session.splash.domain.SplashDestination
+import io.dimasla4ee.shoppinglist.core.mvi.MviState
+
+data class SplashState(
+    val isLoading: Boolean = true,
+    val destination: SplashDestination? = null
+) : MviState

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/splash/presentation/SplashViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/splash/presentation/SplashViewModel.kt
@@ -1,0 +1,53 @@
+package io.dimasla4ee.shoppinglist.app.startup.session.splash.presentation
+
+import io.dimasla4ee.shoppinglist.app.startup.session.domain.AppLaunchRepository
+import io.dimasla4ee.shoppinglist.app.startup.session.presentation.SessionIntent
+import io.dimasla4ee.shoppinglist.app.startup.session.presentation.SessionViewModel
+import io.dimasla4ee.shoppinglist.core.mvi.MviViewModel
+
+class SplashViewModel(
+    private val appLaunchRepository: AppLaunchRepository,
+    private val sessionViewModel: SessionViewModel
+) : MviViewModel<SplashIntent, SplashState, SplashEffect>(
+    initialState = SplashState()
+) {
+
+    override fun reduce(
+        intent: SplashIntent,
+        current: SplashState
+    ): SplashState = when (intent) {
+
+        SplashIntent.Initialize -> {
+            current.copy(isLoading = true)
+        }
+    }
+
+    override suspend fun handleIntent(intent: SplashIntent) {
+        when (intent) {
+            SplashIntent.Initialize -> {
+                initialize()
+            }
+        }
+    }
+
+    private suspend fun initialize() {
+        sessionViewModel.dispatch(
+            SessionIntent.LoadSession
+        )
+        val isFirstLaunch = appLaunchRepository.isFirstLaunch()
+        val effect = when {
+            isFirstLaunch -> {
+                SplashEffect.NavigateToWelcome
+            }
+
+            else -> {
+                SplashEffect.NavigateToShoppingLists
+            }
+        }
+
+        emitEffect(effect)
+        updateState {
+            it.copy(isLoading = false)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/splash/presentation/SplashViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/splash/presentation/SplashViewModel.kt
@@ -1,13 +1,10 @@
 package io.dimasla4ee.shoppinglist.app.startup.session.splash.presentation
 
 import io.dimasla4ee.shoppinglist.app.startup.session.domain.AppLaunchRepository
-import io.dimasla4ee.shoppinglist.app.startup.session.presentation.SessionIntent
-import io.dimasla4ee.shoppinglist.app.startup.session.presentation.SessionViewModel
 import io.dimasla4ee.shoppinglist.core.mvi.MviViewModel
 
 class SplashViewModel(
     private val appLaunchRepository: AppLaunchRepository,
-    private val sessionViewModel: SessionViewModel
 ) : MviViewModel<SplashIntent, SplashState, SplashEffect>(
     initialState = SplashState()
 ) {
@@ -16,38 +13,24 @@ class SplashViewModel(
         intent: SplashIntent,
         current: SplashState
     ): SplashState = when (intent) {
-
-        SplashIntent.Initialize -> {
-            current.copy(isLoading = true)
-        }
+        SplashIntent.Initialize -> current.copy(isLoading = true)
     }
 
     override suspend fun handleIntent(intent: SplashIntent) {
         when (intent) {
-            SplashIntent.Initialize -> {
-                initialize()
-            }
+            SplashIntent.Initialize -> initialize()
         }
     }
 
     private suspend fun initialize() {
-        sessionViewModel.dispatch(
-            SessionIntent.LoadSession
-        )
         val isFirstLaunch = appLaunchRepository.isFirstLaunch()
-        val effect = when {
-            isFirstLaunch -> {
-                SplashEffect.NavigateToWelcome
-            }
 
-            else -> {
+        emitEffect(
+            if (isFirstLaunch) {
+                SplashEffect.NavigateToWelcome
+            } else {
                 SplashEffect.NavigateToShoppingLists
             }
-        }
-
-        emitEffect(effect)
-        updateState {
-            it.copy(isLoading = false)
-        }
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/splash/ui/SplashScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/splash/ui/SplashScreen.kt
@@ -1,14 +1,16 @@
 package io.dimasla4ee.shoppinglist.app.startup.session.splash.ui
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import org.jetbrains.compose.resources.painterResource
 import shoppinglist.composeapp.generated.resources.Res
-import shoppinglist.composeapp.generated.resources.img_main_screen
+import shoppinglist.composeapp.generated.resources.ic_main_logo_78
 
 @Composable
 fun SplashScreen(
@@ -18,8 +20,10 @@ fun SplashScreen(
         modifier = modifier.fillMaxSize(),
         contentAlignment = Alignment.Center
     ) {
-        Image(
-            painter = painterResource(Res.drawable.img_main_screen),
+        Icon(
+            modifier = Modifier.fillMaxSize(0.5f),
+            painter = painterResource(Res.drawable.ic_main_logo_78),
+            tint = contentColorFor(MaterialTheme.colorScheme.background),
             contentDescription = null
         )
     }

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/splash/ui/SplashScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/splash/ui/SplashScreen.kt
@@ -12,6 +12,8 @@ import org.jetbrains.compose.resources.painterResource
 import shoppinglist.composeapp.generated.resources.Res
 import shoppinglist.composeapp.generated.resources.ic_main_logo_78
 
+const val SIZE_FRACTION = 0.5f
+
 @Composable
 fun SplashScreen(
     modifier: Modifier = Modifier
@@ -21,7 +23,7 @@ fun SplashScreen(
         contentAlignment = Alignment.Center
     ) {
         Icon(
-            modifier = Modifier.fillMaxSize(0.5f),
+            modifier = Modifier.fillMaxSize(SIZE_FRACTION),
             painter = painterResource(Res.drawable.ic_main_logo_78),
             tint = contentColorFor(MaterialTheme.colorScheme.background),
             contentDescription = null

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/splash/ui/SplashScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/app/startup/session/splash/ui/SplashScreen.kt
@@ -1,0 +1,26 @@
+package io.dimasla4ee.shoppinglist.app.startup.session.splash.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import org.jetbrains.compose.resources.painterResource
+import shoppinglist.composeapp.generated.resources.Res
+import shoppinglist.composeapp.generated.resources.img_main_screen
+
+@Composable
+fun SplashScreen(
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Image(
+            painter = painterResource(Res.drawable.img_main_screen),
+            contentDescription = null
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/shopping_lists/presentation/ShoppingListsIntent.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/shopping_lists/presentation/ShoppingListsIntent.kt
@@ -63,6 +63,6 @@ sealed interface ShoppingListsIntent : MviIntent {
         val item: ShoppingListItem
     ) : ShoppingListsIntent
 
-    data object AuthorizationClicked : ShoppingListsIntent
+    data class AuthorizationClicked(val isAuthorized: Boolean) : ShoppingListsIntent
     data object LogoutClick : ShoppingListsIntent
 }

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/shopping_lists/presentation/ShoppingListsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/shopping_lists/presentation/ShoppingListsViewModel.kt
@@ -1,6 +1,7 @@
 package io.dimasla4ee.shoppinglist.feature.shopping_lists.presentation
 
 import io.dimasla4ee.shoppinglist.core.domain.interactor.sorting.RemoveSortModeUseCase
+import io.dimasla4ee.shoppinglist.core.domain.repository.AuthRepository
 import io.dimasla4ee.shoppinglist.core.mvi.MviViewModel
 import io.dimasla4ee.shoppinglist.feature.shopping_lists.domain.ShoppingListsInteractor
 import io.dimasla4ee.shoppinglist.feature.shopping_lists.presentation.state.ShoppingListDialog
@@ -13,6 +14,7 @@ import kotlinx.coroutines.launch
 
 class ShoppingListsViewModel(
     private val interactor: ShoppingListsInteractor,
+    private val authRepository: AuthRepository,
     private val removeSortModeUseCase: RemoveSortModeUseCase
 ) : MviViewModel<ShoppingListsIntent, ShoppingListsState, ShoppingListsEffect>(
     initialState = ShoppingListsState()
@@ -243,11 +245,23 @@ class ShoppingListsViewModel(
                 handleListClicked(intent)
             }
 
+            is ShoppingListsIntent.AuthorizationClicked -> with(intent) {
+                when (isAuthorized) {
+                    true -> updateState { it.copy(dialog = ShoppingListDialog.Logout) }
+                    false -> emitEffect(ShoppingListsEffect.NavigateToAuthorization)
+                }
+            }
+
+            is ShoppingListsIntent.LogoutClick -> {
+                authRepository.clearTokens()
+                dispatch(ShoppingListsIntent.DialogDismiss)
+            }
+
             else -> Unit
         }
     }
 
-    private suspend fun handleObserveLists() {
+    private fun handleObserveLists() {
         observeLists()
     }
 

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/shopping_lists/presentation/ShoppingListsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/shopping_lists/presentation/ShoppingListsViewModel.kt
@@ -72,13 +72,6 @@ class ShoppingListsViewModel(
             reduceSheetDismiss(current)
         }
 
-        is ShoppingListsIntent.LogoutClick -> {
-            current.copy(
-                isAuthorized = false,
-                dialog = ShoppingListDialog.None
-            )
-        }
-
         else -> current
     }
 
@@ -248,14 +241,6 @@ class ShoppingListsViewModel(
 
             is ShoppingListsIntent.ListClicked -> {
                 handleListClicked(intent)
-            }
-
-            is ShoppingListsIntent.AuthorizationClicked -> {
-                val currentState = state.value
-                when (currentState.isAuthorized) {
-                    true -> updateState { it.copy(dialog = ShoppingListDialog.Logout) }
-                    false -> emitEffect(ShoppingListsEffect.NavigateToAuthorization)
-                }
             }
 
             else -> Unit

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/shopping_lists/presentation/state/ShoppingListsState.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/shopping_lists/presentation/state/ShoppingListsState.kt
@@ -21,6 +21,5 @@ data class ShoppingListsState(
 
     val deleteTargetId: Long? = null,
 
-    val isFabVisible: Boolean = true,
-    val isAuthorized: Boolean = false
+    val isFabVisible: Boolean = true
 ) : MviState

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/shopping_lists/ui/screen/ShoppingListsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/shopping_lists/ui/screen/ShoppingListsScreen.kt
@@ -47,6 +47,7 @@ import shoppinglist.composeapp.generated.resources.screen_title
 @Composable
 fun ShoppingListsScreen(
     state: ShoppingListsState,
+    isAuthorized: Boolean,
     onIntent: (ShoppingListsIntent) -> Unit,
     onThemeToggle: () -> Unit,
     modifier: Modifier = Modifier
@@ -151,12 +152,12 @@ fun ShoppingListsScreen(
                     onClick = onThemeToggle
                 ),
                 onAuthorizationClick = ActionItem(
-                    iconRes = when (state.isAuthorized) {
+                    iconRes = when (isAuthorized) {
                         true -> Res.drawable.ic_logout_24
                         false -> Res.drawable.ic_login_24
                     },
                     label = stringResource(
-                        if (state.isAuthorized) Res.string.action_logout else Res.string.action_login
+                        if (isAuthorized) Res.string.action_logout else Res.string.action_login
                     ),
                     onClick = { onIntent(ShoppingListsIntent.AuthorizationClicked) }
                 ),
@@ -278,6 +279,7 @@ private fun ShoppingListsScreenPreview(
     ShoppingListTheme {
         ShoppingListsScreen(
             state = state,
+            isAuthorized = true,
             onIntent = {},
             onThemeToggle = {}
         )

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/shopping_lists/ui/screen/ShoppingListsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/shopping_lists/ui/screen/ShoppingListsScreen.kt
@@ -98,25 +98,21 @@ fun ShoppingListsScreen(
                             lists = visibleLists,
                             onEvent = { event ->
                                 val intent = when (event) {
-                                    is ShoppingListCardEvent.Click -> {
+                                    is ShoppingListCardEvent.Click ->
                                         ShoppingListsIntent.ListClicked(event.item)
-                                    }
 
-                                    is ShoppingListCardEvent.Edit -> {
+                                    is ShoppingListCardEvent.Edit ->
                                         ShoppingListsIntent.EditClicked(event.item)
-                                    }
 
-                                    is ShoppingListCardEvent.Copy -> {
+                                    is ShoppingListCardEvent.Copy ->
                                         ShoppingListsIntent.CopyClicked(event.item)
-                                    }
 
-                                    is ShoppingListCardEvent.ChangeIcon -> {
+                                    is ShoppingListCardEvent.ChangeIcon ->
                                         ShoppingListsIntent.ChangeIconClicked(event.item)
-                                    }
 
-                                    is ShoppingListCardEvent.Delete -> {
+                                    is ShoppingListCardEvent.Delete ->
                                         ShoppingListsIntent.DeleteClicked(event.item)
-                                    }
+
                                 }
                                 onIntent(intent)
                             },
@@ -159,7 +155,7 @@ fun ShoppingListsScreen(
                     label = stringResource(
                         if (isAuthorized) Res.string.action_logout else Res.string.action_login
                     ),
-                    onClick = { onIntent(ShoppingListsIntent.AuthorizationClicked) }
+                    onClick = { onIntent(ShoppingListsIntent.AuthorizationClicked(isAuthorized)) }
                 ),
                 onAddListClick = if (state.isFabVisible) {
                     { onIntent(ShoppingListsIntent.FabClick) }
@@ -183,25 +179,20 @@ fun ShoppingListsScreen(
                         lists = visibleLists,
                         onEvent = { event ->
                             val intent = when (event) {
-                                is ShoppingListCardEvent.Click -> {
+                                is ShoppingListCardEvent.Click ->
                                     ShoppingListsIntent.ListClicked(event.item)
-                                }
 
-                                is ShoppingListCardEvent.Edit -> {
+                                is ShoppingListCardEvent.Edit ->
                                     ShoppingListsIntent.EditClicked(event.item)
-                                }
 
-                                is ShoppingListCardEvent.Copy -> {
+                                is ShoppingListCardEvent.Copy ->
                                     ShoppingListsIntent.CopyClicked(event.item)
-                                }
 
-                                is ShoppingListCardEvent.ChangeIcon -> {
+                                is ShoppingListCardEvent.ChangeIcon ->
                                     ShoppingListsIntent.ChangeIconClicked(event.item)
-                                }
 
-                                is ShoppingListCardEvent.Delete -> {
+                                is ShoppingListCardEvent.Delete ->
                                     ShoppingListsIntent.DeleteClicked(event.item)
-                                }
                             }
                             onIntent(intent)
                         },

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,12 +8,13 @@ ksp = "2.3.6"
 # --- SDK ---
 compileSdk = "36"
 minSdk = "27"
+nbvcxz = "1.5.1"
 targetSdk = "36"
 
 # --- Compose Multiplatform ---
-composeMultiplatform = "1.10.3"
+composeMultiplatform = "1.11.0"
 material3 = "1.10.0-alpha05"
-composeHotReload = "1.0.0"
+composeHotReload = "1.1.1"
 
 # --- AndroidX ---
 activity = "1.13.0"
@@ -22,16 +23,16 @@ coreKtx = "1.18.0"
 lifecycle = "2.10.0"
 
 # --- Navigation (KMP) ---
-navigation3 = "1.1.0"
+navigation3 = "1.1.1"
 lifecycleNavigation3 = "2.10.0"
-adaptiveNavigation3 = "1.3.0-alpha02"
+adaptiveNavigation3 = "1.3.0-beta01"
 
 # --- Data ---
-ktor = "3.4.3"
+ktor = "3.5.0"
 ktorfit = "2.7.3"
 kotlinSerialization = "1.11.0"
 room = "2.8.4"
-sqlite-bundled = "2.5.0-alpha06"
+sqlite-bundled = "2.6.2"
 
 # --- DI ---
 koin = "4.2.1"
@@ -40,7 +41,7 @@ koin = "4.2.1"
 coil = "3.4.0"
 
 # --- Coroutines ---
-coroutines = "1.10.2"
+coroutines = "1.11.0"
 
 # --- Tests ---
 junit = "4.13.2"
@@ -50,7 +51,7 @@ testExt = "1.3.0"
 # --- Other ---
 jsoup = "1.22.2"
 detekt = "2.0.0-alpha.3"
-detektCompose = "0.5.8"
+detektCompose = "0.5.9"
 junitJupiterVersion = "6.0.3"
 reorderable = "3.1.0"
 
@@ -76,6 +77,7 @@ compose-components-resources = { module = "org.jetbrains.compose.components:comp
 compose-ui-tooling-preview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "composeMultiplatform" }
 
 # --- Navigation KMP ---
+kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "coroutines" }
 navigation3-ui = { module = "org.jetbrains.androidx.navigation3:navigation3-ui", version.ref = "navigation3" }
 lifecycle-viewmodel-navigation3 = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "lifecycleNavigation3" }
 material3-adaptive-navigation3 = { module = "org.jetbrains.compose.material3.adaptive:adaptive-navigation3", version.ref = "adaptiveNavigation3" }
@@ -102,6 +104,7 @@ ktorfit = { module = "de.jensklingenberg.ktorfit:ktorfit-lib", version.ref = "kt
 ktorfit-ksp = { module = "de.jensklingenberg.ktorfit:ktorfit-ksp", version.ref = "ktorfit" }
 
 # --- Room ---
+nbvcxz = { module = "me.gosimple:nbvcxz", version.ref = "nbvcxz" }
 room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
 room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 sqlite-bundled-lib = { module = "androidx.sqlite:sqlite-bundled", version.ref = "sqlite-bundled" }

--- a/keystore.properties.example
+++ b/keystore.properties.example
@@ -1,0 +1,4 @@
+STORE_FILE=shoppinglist-release.jks
+STORE_PASSWORD=your_password
+KEY_ALIAS=release
+KEY_PASSWORD=your_password


### PR DESCRIPTION
Resolves #148

### Что сделано

#### SplashScreen с проверкой токенов
- Обновлён `SplashScreen`: `Image` заменён на `Icon` с использованием MaterialTheme tinting
- Обновлён логотип на `ic_main_logo_78`
- Размер логотипа установлен на 50% от ширины экрана

#### Рефакторинг SplashViewModel и MVI
- Удалена зависимость `SessionViewModel` из `SplashViewModel`
- Навигационная логика Splash мигрирована с state-based на effect-based в `EntryProvider`
- Упрощены MVI-редукция состояния и обработка интентов во ViewModel
- Очищено форматирование кода, удалены неиспользуемые импорты в `EntryProvider` и `SplashViewModel`

#### Обработка выхода из аккаунта и авторизации
- Добавлена зависимость `AuthRepository` в `ShoppingListsViewModel` для очистки токенов
- Обновлён интент `AuthorizationClicked`: теперь учитывает текущий статус авторизации
- Реализована логика переключения между показом диалога выхода и навигацией на авторизацию
- Добавлена задержка в 1 секунду при инициализации `SplashScreen` в `EntryProvider`
- Улучшена читаемость маппинга интентов в `ShoppingListsScreen`
- `handleObserveLists` изменён на non-suspend функцию во ViewModel

#### Определение первого запуска приложения
- Добавлена ViewModel для отслеживания первого запуска приложения
- В зависимости от статуса первого запуска открываются разные экраны (онбординг/авторизация/основной экран)

### Затронутые файлы
- `feature/splash_screen/ui/SplashScreen.kt`
- `feature/splash_screen/ui/SplashViewModel.kt`
- `app/navigation/EntryProvider.kt`
- `feature/shopping_lists/presentation/ShoppingListsViewModel.kt`
- `feature/shopping_lists/ui/ShoppingListsScreen.kt`
- `core/domain/repository/AuthRepository.kt`
- `feature/first_launch/FirstLaunchViewModel.kt` (новый)