### PR TITLE
Created ShoppingListLogo.kt and refactored portrait screens

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/presentation/components/ShoppingListLogo.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/presentation/components/ShoppingListLogo.kt
@@ -1,6 +1,7 @@
 package io.dimasla4ee.shoppinglist.core.presentation.components
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.InlineTextContent
@@ -9,6 +10,7 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -28,23 +30,31 @@ import shoppinglist.composeapp.generated.resources.welcome_screen_title
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-fun ShoppingListLogo(onWidth: (Dp) -> Unit) {
+fun ShoppingListLogo(
+    onWidth: (Dp) -> Unit,
+    modifier: Modifier = Modifier
+) {
     val (annotatedString, inlineContentMap) = createWelcomeLogo()
     val density = LocalDensity.current
 
-    Text(
-        inlineContent = inlineContentMap,
-        text = annotatedString,
-        style = MaterialTheme.typography.titleLargeEmphasized,
-        color = MaterialTheme.colorScheme.onBackground,
-        textAlign = TextAlign.Center,
-        modifier = Modifier
-            .padding(end = AppDimensions.paddingMedium)
-            .onGloballyPositioned { coordinates ->
-                val width = with(density) { coordinates.size.width.toDp() }
-                onWidth(width)
-            },
-    )
+    Box(
+        modifier = modifier,
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            inlineContent = inlineContentMap,
+            text = annotatedString,
+            style = MaterialTheme.typography.titleLargeEmphasized,
+            color = MaterialTheme.colorScheme.onBackground,
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .padding(end = AppDimensions.paddingMedium)
+                .onGloballyPositioned { coordinates ->
+                    val width = with(density) { coordinates.size.width.toDp() }
+                    onWidth(width)
+                },
+        )
+    }
 }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/presentation/components/ShoppingListLogo.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/presentation/components/ShoppingListLogo.kt
@@ -1,0 +1,75 @@
+package io.dimasla4ee.shoppinglist.core.presentation.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.InlineTextContent
+import androidx.compose.foundation.text.appendInlineContent
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.Placeholder
+import androidx.compose.ui.text.PlaceholderVerticalAlign
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import io.dimasla4ee.shoppinglist.app.ui.theme.AppDimensions
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+import shoppinglist.composeapp.generated.resources.Res
+import shoppinglist.composeapp.generated.resources.ic_main_logo_78
+import shoppinglist.composeapp.generated.resources.welcome_screen_title
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun ShoppingListLogo(onWidthKnown: (Dp) -> Unit) {
+    val (annotatedString, inlineContentMap) = createWelcomeLogo()
+    val density = LocalDensity.current
+
+    Text(
+        inlineContent = inlineContentMap,
+        text = annotatedString,
+        style = MaterialTheme.typography.titleLargeEmphasized,
+        color = MaterialTheme.colorScheme.onBackground,
+        textAlign = TextAlign.Center,
+        modifier = Modifier
+            .padding(end = AppDimensions.paddingMedium)
+            .onGloballyPositioned { coordinates ->
+                val width = with(density) { coordinates.size.width.toDp() }
+                onWidthKnown(width)
+            },
+    )
+}
+
+@Composable
+private fun createWelcomeLogo(): Pair<AnnotatedString, Map<String, InlineTextContent>> {
+    val annotatedString = buildAnnotatedString {
+        appendInlineContent(id = "imageId")
+        append(stringResource(Res.string.welcome_screen_title))
+    }
+
+    val inlineContentMap = mapOf(
+        "imageId" to InlineTextContent(
+            Placeholder(
+                width = AppDimensions.logoSize,
+                height = AppDimensions.logoSize,
+                placeholderVerticalAlign = PlaceholderVerticalAlign.TextCenter
+            )
+        ) {
+            Image(
+                modifier = Modifier.offset(y = AppDimensions.logoOffset),
+                painter = painterResource(Res.drawable.ic_main_logo_78),
+                colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
+                contentDescription = null
+            )
+        }
+    )
+
+    return annotatedString to inlineContentMap
+}

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/presentation/components/ShoppingListLogo.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/core/presentation/components/ShoppingListLogo.kt
@@ -28,7 +28,7 @@ import shoppinglist.composeapp.generated.resources.welcome_screen_title
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-fun ShoppingListLogo(onWidthKnown: (Dp) -> Unit) {
+fun ShoppingListLogo(onWidth: (Dp) -> Unit) {
     val (annotatedString, inlineContentMap) = createWelcomeLogo()
     val density = LocalDensity.current
 
@@ -42,7 +42,7 @@ fun ShoppingListLogo(onWidthKnown: (Dp) -> Unit) {
             .padding(end = AppDimensions.paddingMedium)
             .onGloballyPositioned { coordinates ->
                 val width = with(density) { coordinates.size.width.toDp() }
-                onWidthKnown(width)
+                onWidth(width)
             },
     )
 }

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/ui/AuthorizationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/ui/AuthorizationScreen.kt
@@ -75,7 +75,7 @@ fun AuthorizationScreen(
                     .verticalScroll(scrollState),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                ShoppingListLogo {}
+                ShoppingListLogo({})
 
                 Box(
                     modifier = Modifier.weight(1F),

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/ui/AuthorizationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/ui/AuthorizationScreen.kt
@@ -71,14 +71,15 @@ fun AuthorizationScreen(
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .defaultMinSize(minHeight = maxHeight)
-                    .verticalScroll(scrollState),
+                    .defaultMinSize(minHeight = maxHeight),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 ShoppingListLogo({})
 
                 Box(
-                    modifier = Modifier.weight(1F),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .verticalScroll(scrollState),
                     contentAlignment = Alignment.Center
                 ) {
                     content()

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/ui/AuthorizationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/authorization/ui/AuthorizationScreen.kt
@@ -1,11 +1,10 @@
 package io.dimasla4ee.shoppinglist.feature.authorization.ui
 
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -13,19 +12,17 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MediumTopAppBar
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import io.dimasla4ee.shoppinglist.app.ui.theme.AppDimensions
 import io.dimasla4ee.shoppinglist.app.ui.theme.ShoppingListTheme
+import io.dimasla4ee.shoppinglist.core.presentation.components.ShoppingListLogo
 import io.dimasla4ee.shoppinglist.core.presentation.components.topbar.AppTopBarDefaults
 import io.dimasla4ee.shoppinglist.feature.authorization.presentation.recover_password.RecoverPasswordState
 import io.dimasla4ee.shoppinglist.feature.authorization.presentation.register.RegisterState
@@ -33,7 +30,6 @@ import io.dimasla4ee.shoppinglist.feature.authorization.presentation.sign_in.Sig
 import io.dimasla4ee.shoppinglist.feature.authorization.ui.recover_password.RecoverPasswordContent
 import io.dimasla4ee.shoppinglist.feature.authorization.ui.register.RegisterContent
 import io.dimasla4ee.shoppinglist.feature.authorization.ui.sign_in.SignInContent
-import io.dimasla4ee.shoppinglist.feature.welcome_screen.ui.createWelcomeLogo
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import shoppinglist.composeapp.generated.resources.Res
@@ -47,23 +43,13 @@ fun AuthorizationScreen(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit
 ) {
-    val (annotatedString, inlineContentMap) = createWelcomeLogo()
     val scrollState = rememberScrollState()
 
     Scaffold(
         modifier = modifier,
         topBar = {
-            MediumTopAppBar(
-                title = {
-                    Text(
-                        modifier = Modifier.fillMaxWidth(),
-                        inlineContent = inlineContentMap,
-                        text = annotatedString,
-                        style = MaterialTheme.typography.titleLargeEmphasized,
-                        color = MaterialTheme.colorScheme.onBackground,
-                        textAlign = TextAlign.Center
-                    )
-                },
+            TopAppBar(
+                title = {},
                 navigationIcon = {
                     IconButton(onClick = onBackClick) {
                         Icon(
@@ -84,13 +70,19 @@ fun AuthorizationScreen(
         ) {
             Column(
                 modifier = Modifier
-                    .fillMaxWidth()
+                    .fillMaxSize()
                     .defaultMinSize(minHeight = maxHeight)
                     .verticalScroll(scrollState),
-                verticalArrangement = Arrangement.Center,
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                content()
+                ShoppingListLogo {}
+
+                Box(
+                    modifier = Modifier.weight(1F),
+                    contentAlignment = Alignment.Center
+                ) {
+                    content()
+                }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/products_screen/ui/ItemListPlaceholder.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/products_screen/ui/ItemListPlaceholder.kt
@@ -1,6 +1,7 @@
 package io.dimasla4ee.shoppinglist.feature.products_screen.ui
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,14 +13,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
+import io.dimasla4ee.shoppinglist.app.ui.theme.AppDimensions
 import io.dimasla4ee.shoppinglist.app.ui.theme.LocalAppPlaceholders
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import shoppinglist.composeapp.generated.resources.Res
 import shoppinglist.composeapp.generated.resources.add_items_hint
 import shoppinglist.composeapp.generated.resources.empty_list_message
-import shoppinglist.composeapp.generated.resources.img_product_list
 
 @Composable
 fun ItemListPlaceholder(
@@ -27,33 +27,33 @@ fun ItemListPlaceholder(
 ) {
     // Основной контент экрана
     Column(
-        modifier = modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = AppDimensions.paddingLarge),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
     ) {
         Image(
             painter = painterResource(LocalAppPlaceholders.current.imgProductList),
             contentDescription = null
         )
 
-        Spacer(modifier = Modifier.height(48.dp))
+        Spacer(modifier = Modifier.height(AppDimensions.spacerVeryBig))
 
         Text(
-            modifier = Modifier.padding(horizontal = 44.dp),
+            textAlign = TextAlign.Center,
             text = stringResource(Res.string.empty_list_message),
             style = MaterialTheme.typography.labelLarge,
             color = MaterialTheme.colorScheme.onBackground
         )
 
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(AppDimensions.spacerSmall))
 
         Text(
-            modifier = Modifier.padding(horizontal = 44.dp),
             textAlign = TextAlign.Center,
             text = stringResource(Res.string.add_items_hint),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onBackground
         )
-
-        Spacer(modifier = Modifier.weight(1f))
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/shopping_lists/ui/screen/ShoppingListsEmptyPortrait.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/shopping_lists/ui/screen/ShoppingListsEmptyPortrait.kt
@@ -1,10 +1,10 @@
 package io.dimasla4ee.shoppinglist.feature.shopping_lists.ui.screen
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
@@ -12,7 +12,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import io.dimasla4ee.shoppinglist.app.ui.theme.AppDimensions
@@ -32,15 +31,12 @@ fun ShoppingListsEmptyPortrait(
         modifier = modifier
             .fillMaxSize()
             .padding(horizontal = AppDimensions.paddingLarge),
-        horizontalAlignment = Alignment.CenterHorizontally
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
     ) {
-        Spacer(modifier = Modifier.height(AppDimensions.spacerVeryLarge))
-
         Image(
             painter = painterResource(LocalAppPlaceholders.current.imgShoppingLists),
-            contentDescription = null,
-            modifier = Modifier.fillMaxWidth(),
-            contentScale = ContentScale.Crop
+            contentDescription = null
         )
 
         Spacer(modifier = Modifier.height(AppDimensions.spacerVeryBig))

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/welcome_screen/ui/WelcomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/welcome_screen/ui/WelcomeScreen.kt
@@ -1,81 +1,32 @@
 package io.dimasla4ee.shoppinglist.feature.welcome_screen.ui
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.text.InlineTextContent
-import androidx.compose.foundation.text.appendInlineContent
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.Placeholder
-import androidx.compose.ui.text.PlaceholderVerticalAlign
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
-import io.dimasla4ee.shoppinglist.app.ui.theme.AppDimensions
 import io.dimasla4ee.shoppinglist.app.ui.theme.ShoppingListTheme
 import io.dimasla4ee.shoppinglist.utils.OrientationProvider
 import io.dimasla4ee.shoppinglist.utils.ScreenOrientation
-import org.jetbrains.compose.resources.painterResource
-import org.jetbrains.compose.resources.stringResource
-import shoppinglist.composeapp.generated.resources.Res
-import shoppinglist.composeapp.generated.resources.ic_main_logo_78
-import shoppinglist.composeapp.generated.resources.welcome_screen_title
 
 @Composable
 fun WelcomeScreen(
     onGoToShopping: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val (annotatedString, inlineContentMap) = createWelcomeLogo()
-
     OrientationProvider { orientation ->
         when (orientation) {
             ScreenOrientation.PORTRAIT -> WelcomeScreenPortrait(
                 onGoToShopping,
-                annotatedString,
-                inlineContentMap,
                 modifier
             )
 
             ScreenOrientation.LANDSCAPE -> WelcomeScreenLandscape(
                 onGoToShopping,
-                annotatedString,
-                inlineContentMap,
                 modifier
             )
         }
     }
-}
-
-@Composable
-fun createWelcomeLogo(): Pair<AnnotatedString, Map<String, InlineTextContent>> {
-    val annotatedString = buildAnnotatedString {
-        appendInlineContent(id = "imageId")
-        append(stringResource(Res.string.welcome_screen_title))
-    }
-
-    val inlineContentMap = mapOf(
-        "imageId" to InlineTextContent(
-            Placeholder(
-                width = AppDimensions.logoSize,
-                height = AppDimensions.logoSize,
-                placeholderVerticalAlign = PlaceholderVerticalAlign.TextCenter
-            )
-        ) {
-            Image(
-                modifier = Modifier.offset(y = AppDimensions.logoOffset),
-                painter = painterResource(Res.drawable.ic_main_logo_78),
-                colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
-                contentDescription = null
-            )
-        }
-    )
-
-    return annotatedString to inlineContentMap
 }
 
 @Preview(showSystemUi = true)

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/welcome_screen/ui/WelcomeScreenLandscape.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/welcome_screen/ui/WelcomeScreenLandscape.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.text.InlineTextContent
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
@@ -30,13 +29,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.dimasla4ee.shoppinglist.app.ui.theme.AppDimensions
 import io.dimasla4ee.shoppinglist.app.ui.theme.LocalAppPlaceholders
 import io.dimasla4ee.shoppinglist.app.ui.theme.ShoppingListTheme
+import io.dimasla4ee.shoppinglist.core.presentation.components.ShoppingListLogo
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import shoppinglist.composeapp.generated.resources.Res
@@ -48,8 +47,6 @@ import shoppinglist.composeapp.generated.resources.shopping
 @Composable
 fun WelcomeScreenLandscape(
     onGoToShopping: () -> Unit,
-    annotatedString: AnnotatedString,
-    inlineContentMap: Map<String, InlineTextContent>,
     modifier: Modifier = Modifier
 ) {
     var showContent by remember { mutableStateOf(true) }
@@ -102,20 +99,7 @@ fun WelcomeScreenLandscape(
                     modifier = Modifier.weight(1F),
                     contentAlignment = Alignment.Center
                 ) {
-                    Text(
-                        inlineContent = inlineContentMap,
-                        text = annotatedString,
-                        style = MaterialTheme.typography.titleLargeEmphasized,
-                        color = MaterialTheme.colorScheme.onBackground,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier
-                            .padding(end = AppDimensions.paddingMedium)
-                            .onGloballyPositioned { coordinates ->
-                                logoWidth = with(density) {
-                                    coordinates.size.width.toDp()
-                                }
-                            },
-                    )
+                    ShoppingListLogo { width -> logoWidth = width }
                 }
 
                 AnimatedVisibility(
@@ -176,12 +160,9 @@ fun WelcomeScreenLandscape(
 @Composable
 private fun WelcomeScreenLandscapePreview() {
     ShoppingListTheme {
-        val (annotatedString, inlineContentMap) = createWelcomeLogo()
         WelcomeScreenLandscape(
             onGoToShopping = {},
-            modifier = Modifier.fillMaxSize(),
-            annotatedString = annotatedString,
-            inlineContentMap = inlineContentMap
+            modifier = Modifier.fillMaxSize()
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/welcome_screen/ui/WelcomeScreenLandscape.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/welcome_screen/ui/WelcomeScreenLandscape.kt
@@ -99,7 +99,7 @@ fun WelcomeScreenLandscape(
                     modifier = Modifier.weight(1F),
                     contentAlignment = Alignment.Center
                 ) {
-                    ShoppingListLogo { width -> logoWidth = width }
+                    ShoppingListLogo({ width -> logoWidth = width })
                 }
 
                 AnimatedVisibility(

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/welcome_screen/ui/WelcomeScreenPortrait.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/welcome_screen/ui/WelcomeScreenPortrait.kt
@@ -54,7 +54,7 @@ fun WelcomeScreenPortrait(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Top
     ) {
-        ShoppingListLogo { width -> logoWidth = width }
+        ShoppingListLogo({ width -> logoWidth = width })
 
         AnimatedVisibility(
             modifier = Modifier.weight(1F),

--- a/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/welcome_screen/ui/WelcomeScreenPortrait.kt
+++ b/composeApp/src/commonMain/kotlin/io/dimasla4ee/shoppinglist/feature/welcome_screen/ui/WelcomeScreenPortrait.kt
@@ -3,7 +3,6 @@ package io.dimasla4ee.shoppinglist.feature.welcome_screen.ui
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -13,7 +12,6 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.text.InlineTextContent
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
@@ -25,16 +23,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.dimasla4ee.shoppinglist.app.ui.theme.AppDimensions
 import io.dimasla4ee.shoppinglist.app.ui.theme.LocalAppPlaceholders
 import io.dimasla4ee.shoppinglist.app.ui.theme.ShoppingListTheme
+import io.dimasla4ee.shoppinglist.core.presentation.components.ShoppingListLogo
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import shoppinglist.composeapp.generated.resources.Res
@@ -46,13 +41,9 @@ import shoppinglist.composeapp.generated.resources.shopping
 @Composable
 fun WelcomeScreenPortrait(
     onGoToShopping: () -> Unit,
-    annotatedString: AnnotatedString,
-    inlineContentMap: Map<String, InlineTextContent>,
     modifier: Modifier = Modifier
 ) {
-    var showContent by remember { mutableStateOf(true) }
     var clicked by remember { mutableStateOf(false) }
-    val density = LocalDensity.current
     var logoWidth by remember { mutableStateOf(0.dp) }
 
     Column(
@@ -63,40 +54,22 @@ fun WelcomeScreenPortrait(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Top
     ) {
-        Box(
-            contentAlignment = Alignment.Center
+        ShoppingListLogo { width -> logoWidth = width }
+
+        AnimatedVisibility(
+            modifier = Modifier.weight(1F),
+            visible = true
         ) {
-            Text(
-                inlineContent = inlineContentMap,
-                text = annotatedString,
-                style = MaterialTheme.typography.titleLargeEmphasized,
-                color = MaterialTheme.colorScheme.onBackground,
-                textAlign = TextAlign.Center,
-                modifier = Modifier
-                    .padding(end = AppDimensions.paddingMedium)
-                    .onGloballyPositioned { coordinates ->
-                        logoWidth = with(density) {
-                            coordinates.size.width.toDp()
-                        }
-                    },
-            )
-        }
-
-        Spacer(modifier = Modifier.height(AppDimensions.spacerLarge))
-
-        AnimatedVisibility(visible = showContent) {
-
             Column(
                 modifier = Modifier
-                    .fillMaxWidth()
+                    .fillMaxSize()
                     .padding(horizontal = AppDimensions.paddingLarge),
                 horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
             ) {
                 Image(
                     painter = painterResource(LocalAppPlaceholders.current.imgMainScreen),
-                    contentDescription = null,
-                    modifier = Modifier.fillMaxWidth(),
-                    contentScale = ContentScale.Crop
+                    contentDescription = null
                 )
 
                 Spacer(modifier = Modifier.height(AppDimensions.spacerVeryBig))
@@ -116,23 +89,23 @@ fun WelcomeScreenPortrait(
                     color = MaterialTheme.colorScheme.onBackground,
                     style = MaterialTheme.typography.bodyMedium
                 )
-            }
-        }
 
-        Spacer(modifier = Modifier.height(AppDimensions.spacerSmall))
+                Spacer(modifier = Modifier.height(AppDimensions.spacerSmall))
 
-        Button(
-            onClick = {
-                if (!clicked) {
-                    clicked = true
-                    onGoToShopping()
+                Button(
+                    onClick = {
+                        if (!clicked) {
+                            clicked = true
+                            onGoToShopping()
+                        }
+                    },
+                    modifier = Modifier
+                        .widthIn(max = logoWidth)
+                        .fillMaxWidth()
+                ) {
+                    Text(text = stringResource(Res.string.shopping))
                 }
-            },
-            modifier = Modifier
-                .widthIn(max = logoWidth)
-                .fillMaxWidth()
-        ) {
-            Text(text = stringResource(Res.string.shopping))
+            }
         }
     }
 }
@@ -141,12 +114,9 @@ fun WelcomeScreenPortrait(
 @Composable
 private fun WelcomeScreenPortraitPreview() {
     ShoppingListTheme {
-        val (annotatedString, inlineContentMap) = createWelcomeLogo()
         WelcomeScreenPortrait(
             onGoToShopping = {},
-            modifier = Modifier.fillMaxSize(),
-            annotatedString = annotatedString,
-            inlineContentMap = inlineContentMap
+            modifier = Modifier.fillMaxSize()
         )
     }
 }


### PR DESCRIPTION
- Создал функцию ShoppingListLogo() в core.presentation.components для переиспользования на разных экранах
- Переработал портретные ориентации для поддержки экранов разных размеров
- Изображения плейсхолдеров теперь уменьшаются на маленьких экранах и ограничены собственным размером на больших экранах (так выглядит более лаконично на мой взгляд)